### PR TITLE
The value "center" was hard-coded for the anchor attribute, so was impos...

### DIFF
--- a/bi-platform-v2-plugin/cdf/js/lib/CCC/pvc-d1.0.js
+++ b/bi-platform-v2-plugin/cdf/js/lib/CCC/pvc-d1.0.js
@@ -1,4 +1,3 @@
-
 var pvc = {
 
   debug: false
@@ -6245,7 +6244,7 @@ pvc.WaterfallChartPanel = pvc.BasePanel.extend({
 
         if(this.showValues){
             this.pvBarLabel = this.pvBar
-            .anchor("center")
+            .anchor(this.valuesAnchor)
             .add(pv.Label)
             .bottom(0)
             .text(function(d){


### PR DESCRIPTION
...sible to align the values on bar charts corretly, as was supposed to work when setting the "valuesAnchor" attribute.
