### PR TITLE
doQuery function with error (file Dashboards.js)

### DIFF
--- a/bi-platform-v2-plugin/cdf/js/Dashboards.js
+++ b/bi-platform-v2-plugin/cdf/js/Dashboards.js
@@ -1534,12 +1534,12 @@ Query = function() {
      */
 
   var doQuery = function(outsideCallback){
-    if (typeof _callback != 'function') {
-      throw 'QueryNotInitialized';
-    }
     var url;
     var queryDefinition; 
     var callback = (outsideCallback ? outsideCallback : _callback);
+    if (typeof callback != 'function') {
+      throw 'QueryNotInitialized';
+    }
     if (_mode == 'CDA') {
       url = CDA_PATH;
       queryDefinition = buildQueryDefinition();


### PR DESCRIPTION
When fetchData is called only with callback argument and _callback field is not set, the 'QueryNotInitialized' is launched.
