### PR TITLE
AMD Module Root declaration

### DIFF
--- a/bi-platform-v2-plugin/resource/settings.xml
+++ b/bi-platform-v2-plugin/resource/settings.xml
@@ -14,4 +14,8 @@
         valid values are: true | false
      -->
     <hibernate-available>true</hibernate-available>
+
+    <!-- Register the AMD namespace so RequireJS require/define can find the cdf modules -->
+    <amd-root-path>content/pentaho-cdf/js</amd-root-path>
+    <amd-root-namespace>cdf</amd-root-namespace>
 </settings>


### PR DESCRIPTION
We need the AMD module root to load CDF in debug mode in Common UI and Report Viewer now that we've implemented AMD modules using RequireJS.
