### PR TITLE
Ensuring persistence of Sprintf attribution in compressed versions of CDF

### DIFF
--- a/bi-platform-v2-plugin/cdf/js/Dashboards.js
+++ b/bi-platform-v2-plugin/cdf/js/Dashboards.js
@@ -1535,7 +1535,7 @@ function doCsvQuoting(value, separator, alwaysEscape){
   return value;
 };
 
-/**
+/*!
 *
 *  Javascript sprintf
 *  http://www.webtoolkit.info/


### PR DESCRIPTION
simple adding the "!" at the start of the comment allows it to stay in the compressed build
