### PR TITLE
[PPP-2884] Ensuring sprintf attribution comment is preserved in compressed CDF

### DIFF
--- a/bi-platform-v2-plugin/cdf/js/Dashboards.js
+++ b/bi-platform-v2-plugin/cdf/js/Dashboards.js
@@ -1313,7 +1313,7 @@ function doCsvQuoting(value, separator, alwaysEscape){
   return value;
 };
 
-/**
+/*!
 *
 *  Javascript sprintf
 *  http://www.webtoolkit.info/


### PR DESCRIPTION
Adding the "!" allows the comment to remain in the compressed version.
