### PR TITLE
Correcting module name, this was preventing the script from executing

### DIFF
--- a/bi-platform-v2-plugin/cdf/js/lib/CCC/protovis-msie.js
+++ b/bi-platform-v2-plugin/cdf/js/lib/CCC/protovis-msie.js
@@ -1,4 +1,4 @@
-pen.define("cdf/lib/protovis-msie", ["cdf/lib/CCC/protovis"], function(pv){
+pen.define("cdf/lib/CCC/protovis-msie", ["cdf/lib/CCC/protovis"], function(pv){
 /*!
  * Protovis MSIE/VML addon
  * Copyright (C) 2011 by DataMarket <http://datamarket.com>


### PR DESCRIPTION
Under the new RequireJS 2.0 strict ruleset modules will not load unless explicitly requested, the bad module name was preventing this.
