### PR TITLE
Fixing shim configuration for Tipsy. Ported build.xml code from 4.8 whic...

### DIFF
--- a/bi-platform-v2-plugin/build.xml
+++ b/bi-platform-v2-plugin/build.xml
@@ -164,7 +164,7 @@
 		   <mkdir dir="${stage.dir}/${plugin.name}/lib" />
 
 <mkdir dir="${stage.dir}/${plugin.name}/resources/actions" />
-	
+
 		   <!-- copy the plugin jar to the plugin dist lib folder -->
 		   <copy todir="${stage.dir}/${plugin.name}/lib" overwrite="true">
 			   <fileset dir="${dist.dir}">
@@ -202,10 +202,10 @@
 		   </copy>
 
 		   <!-- create the version file -->
-		   <tstamp/>			
+		   <tstamp/>
 			<property name="sequential.build.id" value="manual-${DSTAMP}"/>
 
-		   <echo file="${stage.dir}/${plugin.name}/version.xml" message="&lt;version branch='TRUNK' buildId='${sequential.build.id}'>${project.revision}&lt;/version>"/>		   
+		   <echo file="${stage.dir}/${plugin.name}/version.xml" message="&lt;version branch='TRUNK' buildId='${sequential.build.id}'>${project.revision}&lt;/version>"/>
 
 
 		   <!-- Copy js folder into dist -->
@@ -214,6 +214,10 @@
 				   <include name="**/*" />
 			   </fileset>
 		   </copy>
+
+
+       <!-- blank out the AMD module as the Shim configuration is used at runtime instead -->
+       <echo message="" file="${stage.dir}/${plugin.name}/js/cdf-module.js"/>
 
 		   <replace file="${stage.dir}/${plugin.name}/resources/languages/Messages.properties" token="Version 4.0" value="Version ${project.revision}"/> 
     <replace file="${stage.dir}/${plugin.name}/resources/languages/Messages_en.properties" token="Version 4.0" value="Version ${project.revision}"/> 

--- a/bi-platform-v2-plugin/cdf/js/cdf-require-js-cfg.js
+++ b/bi-platform-v2-plugin/cdf/js/cdf-require-js-cfg.js
@@ -1,66 +1,66 @@
 requireCfg['paths']['cdf'] = CONTEXT_PATH+'content/pentaho-cdf/js';
 requireCfg['shim']['cdf/cdf-module'] = ['cdf/Dashboards',
-	'cdf/jquery.ui',
-	'cdf/jquery-impromptu.3.1',
-	'cdf/jquery-ui-datepicker-i18n',
-	'cdf/jquery.bgiframe',
-	'cdf/jquery.blockUI',
-	'cdf/jquery.corner',
-	'cdf/jquery.eventstack',
-	'cdf/jquery.i18n.properties',
-	'cdf/jquery.jdMenu',
-	'cdf/jquery.positionBy',
-	'cdf/jquery.sparkline',
-	'cdf/jquery.tooltip',
-	'cdf/simile/ajax/simile-ajax-api',
-	'cdf/simile/ajax/scripts/json',
-	'cdf/json',
-    'cdf/lib/shims',
-    'cdf/lib/CCC/pvc-d1.0',
-    'cdf/lib/CCC/protovis', 
-    'cdf/lib/CCC/tipsy', 
-    'cdf/lib/CCC/jquery.tipsy', 
-    'cdf/lib/CCC/def',    
-	'cdf/backbone',
-	'cdf/underscore',
-	'cdf/mustache',
-	'cdf/components/ccc',
-	'cdf/components/core',
-    'cdf/components/input'	,
-    'cdf/components/jfreechart',    
-    'cdf/components/maps',
-    'cdf/components/navigation',
-    'cdf/components/pentaho',
-    'cdf/components/simpleautocomplete',
-	'cdf/components/table'];
+  'cdf/jquery.ui',
+  'cdf/jquery-impromptu.3.1',
+  'cdf/jquery-ui-datepicker-i18n',
+  'cdf/jquery.bgiframe',
+  'cdf/jquery.blockUI',
+  'cdf/jquery.corner',
+  'cdf/jquery.eventstack',
+  'cdf/jquery.i18n.properties',
+  'cdf/jquery.jdMenu',
+  'cdf/jquery.positionBy',
+  'cdf/jquery.sparkline',
+  'cdf/jquery.tooltip',
+  'cdf/simile/ajax/simile-ajax-api',
+  'cdf/simile/ajax/scripts/json',
+  'cdf/json',
+  'cdf/lib/shims',
+  'cdf/lib/CCC/pvc-d1.0',
+  'cdf/lib/CCC/protovis',
+  'cdf/lib/CCC/tipsy',
+  'cdf/lib/CCC/jquery.tipsy',
+  'cdf/lib/CCC/def',
+  'cdf/backbone',
+  'cdf/underscore',
+  'cdf/mustache',
+  'cdf/components/ccc',
+  'cdf/components/core',
+  'cdf/components/input'	,
+  'cdf/components/jfreechart',
+  'cdf/components/maps',
+  'cdf/components/navigation',
+  'cdf/components/pentaho',
+  'cdf/components/simpleautocomplete',
+  'cdf/components/table'];
 
 
 requireCfg['shim']['cdf/CoreComponents'] = [
-	'cdf/components/core',
-	'cdf/components/ccc',
-    'cdf/components/input'	,
-    'cdf/components/jfreechart',    
-    'cdf/components/maps',
-    'cdf/components/navigation',
-    'cdf/components/pentaho',
-    'cdf/components/simpleautocomplete',
-	'cdf/components/table'
+  'cdf/components/core',
+  'cdf/components/ccc',
+  'cdf/components/input'	,
+  'cdf/components/jfreechart',
+  'cdf/components/maps',
+  'cdf/components/navigation',
+  'cdf/components/pentaho',
+  'cdf/components/simpleautocomplete',
+  'cdf/components/table'
 ];
 
 
 
 requireCfg['shim']['cdf/Dashboards'] = [
-    'cdf/Base',
-    'cdf/underscore',
-    'cdf/backbone',
-    'cdf/mustache', 
-    'cdf/lib/shims'    
+  'cdf/Base',
+  'cdf/underscore',
+  'cdf/backbone',
+  'cdf/mustache',
+  'cdf/lib/shims'
 ];
 
 
 requireCfg['shim']['cdf/backbone'] = ['cdf/underscore'];
 requireCfg['shim']['cdf/lib/CCC/pvc-d1.0'] = ['cdf/lib/CCC/protovis', 'cdf/lib/CCC/tipsy', 'cdf/lib/CCC/jquery.tipsy', 'cdf/lib/CCC/def'];
-
+requireCfg['shim']['cdf/lib/CCC/tipsy'] = ['cdf/lib/CCC/protovis'];
 requireCfg['shim']['cdf/components/core'] = ['cdf/Dashboards'];
 requireCfg['shim']['cdf/components/ccc'] = ['cdf/components/core', 'cdf/lib/CCC/pvc-d1.0'];
 requireCfg['shim']['cdf/components/input'] = ['cdf/components/core'];


### PR DESCRIPTION
...h handles wiping out the cdf-module.js which should be empty at deployment.
