### PR TITLE
PDB-1479 / CUST-107: Change jquery loading order.

### DIFF
--- a/bi-platform-v2-plugin/cdf/js/cdf-module.js
+++ b/bi-platform-v2-plugin/cdf/js/cdf-module.js
@@ -1,5 +1,4 @@
-define(['cdf/Base',
-  'cdf/Dashboards',
+define([
   'cdf/jquery',
   'cdf/jquery.ui',
   'cdf/jquery-impromptu.3.1',
@@ -15,6 +14,8 @@ define(['cdf/Base',
   'cdf/json',
   'cdf/simile/ajax/simile-ajax-api',
   'cdf/simile/ajax/scripts/json',
-  'cdf/CoreComponents'], function(){
-	
+  'cdf/Base',
+  'cdf/Dashboards',
+  'cdf/CoreComponents'
+], function(){
 });


### PR DESCRIPTION
Load jquery before Dashboards so Dashboards configures the right instance of jQuery.
(Dashboards configures jQuery to use "traditional" ajax requests)
