### PR TITLE
Make pvSparkline rendering respect canvas margin

### DIFF
--- a/bi-platform-v2-plugin/cdf/js/addIns/coltypes.js
+++ b/bi-platform-v2-plugin/cdf/js/addIns/coltypes.js
@@ -81,7 +81,7 @@
       sparklineData = st.value,
       data = sparklineData.split(",");
       n = data.length,
-      w = opt.width || ph.width(),
+      w = opt.width || ph.width() - opt.canvasMargin * 2,
       h = opt.height,
       min = pv.min.index(data),
       max = pv.max.index(data);


### PR DESCRIPTION
This seems to fix the right-hand "edge creep" of the pvSparkline add-in (CDF Bug #2266).
