### PR TITLE
5.0-RC1 Build - Dashboards not working.

### DIFF
--- a/bi-platform-v2-plugin/cdf/js/cdf-module.js
+++ b/bi-platform-v2-plugin/cdf/js/cdf-module.js
@@ -11,11 +11,33 @@ define([
   'cdf/jquery.positionBy',
   'cdf/jquery.sparkline',
   'cdf/jquery.tooltip',
-  'cdf/json',
+
+  'cdf/Base',
+  'cdf/underscore',
+  'cdf/backbone',
+  'cdf/mustache',
+  'cdf/lib/shims',
+  'cdf/Dashboards',
+
   'cdf/simile/ajax/simile-ajax-api',
   'cdf/simile/ajax/scripts/json',
-  'cdf/Base',
-  'cdf/Dashboards',
-  'cdf/CoreComponents'
-], function(){
-});
+
+  'cdf/lib/CCC/pvc-d1.0',
+  'cdf/lib/CCC/protovis',
+  'cdf/lib/CCC/jquery.tipsy',
+  'cdf/lib/CCC/tipsy',
+  'cdf/lib/CCC/def',
+
+  'cdf/components/core',
+  'cdf/components/ccc',
+  'cdf/components/input'	,
+  'cdf/components/jfreechart',
+  'cdf/components/maps',
+  'cdf/components/navigation',
+  'cdf/components/pentaho',
+  'cdf/components/simpleautocomplete',
+  'cdf/components/table'
+
+],
+    function(){
+    });


### PR DESCRIPTION
Turns out this was all build-related, no real code changes needed. 
First, Dashboards was using the wrong version of CDF (JCR-SNAPSHOT rather than TRUNK-SNAPSHOT). 
2nd, the 5.0 branch of CDF (which currently sources the TRUNK-SNAPSHOT artifact) wasn't including everything it needs in it's requirejs module definition.
