### PR TITLE
[CDE-214] [core-refactor] resource-<style> files are not being included ...

### DIFF
--- a/cdf-pentaho/build.xml
+++ b/cdf-pentaho/build.xml
@@ -104,7 +104,7 @@
 		  </javac>
 	</target>
 
-	<target name="dist" depends="clean-dist,resolve,resolve-js, jar,dist-plugin,write-properties,dist-solution,dist-samples,dist-js"/>
+	<target name="dist" depends="clean-dist,resolve,resolve-js,jar,dist-plugin,dist-solution,dist-samples,dist-js"/>
 
 	<target name="dist-compile" depends="clean-dist,jar,dist-plugin"/>
 
@@ -213,6 +213,7 @@
 		   </fileset>
 	    </copy>
 
+	    <antcall target="write-properties" />
 	    <!-- copy ccc build -->
         <copy todir="${stage.dir}/${plugin.name}/js/lib/CCC" >
             <fileset dir="${js.expanded.lib.dir}/ccc/ccc"/>

--- a/cdf-pentaho5/build.xml
+++ b/cdf-pentaho5/build.xml
@@ -104,7 +104,7 @@
 		  </javac>
 	</target>
 
-	<target name="dist" depends="clean-dist,resolve,resolve-js,jar,dist-plugin,write-properties,dist-solution,dist-samples,dist-js"/>
+	<target name="dist" depends="clean-dist,resolve,resolve-js,jar,dist-plugin,dist-solution,dist-samples,dist-js"/>
 
 	<target name="dist-compile" depends="clean-dist,jar,dist-plugin"/>
 
@@ -214,6 +214,7 @@
 		   </fileset>
 	    </copy>
 
+	    <antcall target="write-properties" />
 	    <!-- copy ccc build -->
         <copy todir="${stage.dir}/${plugin.name}/js/lib/CCC" >
             <fileset dir="${js.expanded.lib.dir}/ccc/pen"/>

--- a/cdf-pentaho5/resource/plugin.spring.xml
+++ b/cdf-pentaho5/resource/plugin.spring.xml
@@ -15,7 +15,7 @@
   <bean id="storage" class="org.pentaho.cdf.storage.StorageApi"/>
   <bean id="comments" class="org.pentaho.cdf.comments.CommentsApi"/>
   <bean id="settings" class="org.pentaho.cdf.settings.SettingsApi"/>
-  <bean id="resources" class="org.pentaho.cdf.ResourcesApi"/>
+  <bean id="cdfResources" class="org.pentaho.cdf.ResourcesApi"/>
   <bean id="views" class="org.pentaho.cdf.views.ViewsApi"/>
   <bean id="cdfApi" class="org.pentaho.cdf.CdfApi"/>
 


### PR DESCRIPTION
...in the distribution zip files

```
- also: in plugin.spring.xml, renamed bean "resources" to "cdfResources", so that spring stops complaining about encountering a bean with that reserved keyword as id
```
