### PR TITLE
changes contentType to match required one in 5.0 RepositoryResource's PO...

### DIFF
--- a/cdf-core/cdf/js/jquery.i18n.properties.js
+++ b/cdf-core/cdf/js/jquery.i18n.properties.js
@@ -104,7 +104,7 @@ function loadAndParseFile(filename, language, mode) {
     $.ajax({
         url:        filename,
         async:      false,
-        contentType: "text/plain;charset=UTF-8",
+        contentType: "application/x-www-form-urlencoded",
         dataType:   'text',
         success:    function(data, status) {
                        var parsed = '';


### PR DESCRIPTION
...ST request; this is being done here also because this project is no longer active (i.e. has no active releases) since May 2011 (as per http://codingwithcoffee.com/?p=272 and https://code.google.com/p/jquery-i18n-properties/downloads/list)
