### PR TITLE
[CDF-205] - CDF core-refactor

### DIFF
--- a/cdf-core/cdf/js/Dashboards.Utils.js
+++ b/cdf-core/cdf/js/Dashboards.Utils.js
@@ -63,9 +63,9 @@ Dashboards.getQueryParameter = function ( parameterName ) {
       // Return the string
       return decodeURIComponent ( queryString.substring ( begin, end ) );
     }
-    // Return "" if no parameter has been found
-    return "";
   }
+  // Return "" if no parameter has been found
+  return "";
 };
 
 (function (D) {


### PR DESCRIPTION
- if no parameters in URL Dashboards.getQueryParameter doesn't return an empty string and NavigatorBaseComponent crashes because it uses "undefined" as path value instead of ""
