### PR TITLE
[CDE-269] - Missing absRoot assignment and added override for StringFilt...

### DIFF
--- a/cdf-core/src/org/pentaho/cdf/packager/CdfHeadersProvider.java
+++ b/cdf-core/src/org/pentaho/cdf/packager/CdfHeadersProvider.java
@@ -347,11 +347,17 @@ public class CdfHeadersProvider implements ICdfHeadersProvider {
     public AbsolutizingStringFilter( String absRoot, StringFilter delegate ) {
       assert delegate != null;
       this.delegate = delegate;
+      this.absRoot = absRoot;
     }
 
     @Override
     public String filter( String input ) {
-      return delegate.filter( Util.joinPath( absRoot, input ) );
+      return delegate.filter( input, absRoot );
+    }
+
+    @Override
+    public String filter( String input, String absRoot ) {
+      return delegate.filter( input, absRoot );
     }
   }
 


### PR DESCRIPTION
...er based on the absRoot
