### PR TITLE
[PDB-1739] - Dashboards with prompts appear un-rendered in view mode

### DIFF
--- a/cdf-core/cdf/js/Dashboards.Main.js
+++ b/cdf-core/cdf/js/Dashboards.Main.js
@@ -151,6 +151,7 @@ Dashboards.bindControl = function(control) {
 Dashboards.bindExistingControl = function(control, Class) {
   if(!control.dashboard) {
     control.dashboard = this;
+    delete control.initInstance;
 
     // Ensure BaseComponent's methods
     this._castControlToComponent(control, Class);
@@ -698,7 +699,9 @@ Dashboards.initEngine = function(initInstance) {
   }
 
   var myself = this;
-  var components = _.where(this.components,{initInstance: initInstance});
+  var components = initInstance != null 
+    ? _.where(this.components, {initInstance: initInstance})
+    : this.components;
 
   if( (!this.waitingForInit || this.waitingForInit.length === 0) && !this.finishedInit ){
     this.incrementRunningCalls();


### PR DESCRIPTION
- Pentaho Dashboards Designer started saving the new initInstance property, when saving dashboards. Later, when reopening the dashboard, in View or Edit mode, the initialization of all saved CDF components with "executeAtStart" would not occur, cause the deserialized `initInstance` property would then be the string `"0"` instead of the number `0`. A related issue was that, upon resize, the call that PDD makes directly to `Dashboards.initEngine`, without arguments, to force re-rendering of all "executeAtStart" components, would not update any component, because of the addition of the argument `initInstance`, that causes updating only components having the given `initInstance`.

@pamval, @dkincade, @rfellows please review.
