### PR TITLE
[CDF-349] - Dashboards.removeComponent does not remove components with t...

### DIFF
--- a/cdf-core/test-js/core-spec.js
+++ b/cdf-core/test-js/core-spec.js
@@ -37,8 +37,7 @@ describe("The CDF framework #", function() {
     type: "managedFreeform",
     preExecution: function() {},
     customfunction: function() {},
-    postExecution: function(){},
-    size: "1"
+    postExecution: function(){}
   };
   var shouldNotUpdate =  {
     name: "shouldNotUpdate",
@@ -116,13 +115,30 @@ describe("The CDF framework #", function() {
     /**
      * ## The CDF framework # getComponentName returns undefined when a component with no name property is provided
      */
-    it("returns undefined when a component with no name property is provide",function(done) {
+    it("returns undefined when a component with no name property is provided",function(done) {
       var tmp = {};
       $.extend( tmp, shouldUpdate );
       tmp.name = null;
       expect(myDashboard.getComponentName(tmp)).toEqual(undefined);
       tmp.name = shouldUpdate.name;
-      expect(myDashboard.getComponentName(tmp)).toEqual("shouldUpdate");
+      expect(myDashboard.getComponentName(tmp)).toEqual(shouldUpdate.name);
+      done();
+    });
+    /**
+     * ## The CDF framework # getComponentName returns undefined when an empty string is provided
+     */
+    it("returns undefined when an empty string is provided",function(done) {
+      expect(myDashboard.getComponentName("")).toEqual(undefined);
+      done();
+    });
+    /**
+     * ## The CDF framework # getComponentName returns undefined when a component has an empty string in property name
+     */
+    it("returns undefined when a component has an empty string in property name",function(done) {
+      var tmp = {};
+      $.extend( tmp, shouldUpdate );
+      tmp.name = "";
+      expect(myDashboard.getComponentName(tmp)).toEqual(undefined);
       done();
     });
   });
@@ -152,6 +168,111 @@ describe("The CDF framework #", function() {
       expect(myDashboard.getComponent(shouldUpdate)).toEqual(shouldUpdate);
       done();
     });
+    /**
+     * ## The CDF framework # getComponent returns undefined when an empty string is provided
+     */
+    it("returns undefined when an empty string is provided",function(done) {
+      expect(myDashboard.getComponent("")).toEqual(undefined);
+      done();
+    });
+    /**
+     * ## The CDF framework # getComponent returns undefined when a component has an empty string in property name
+     */
+    it("returns undefined when a component has an empty string in property name",function(done) {
+      var tmp = {};
+      $.extend( tmp, shouldUpdate );
+      tmp.name = "";
+      expect(myDashboard.getComponent(tmp)).toEqual(undefined);
+      done();
+    });
+  });
+  /**
+   * ## The CDF framework # getComponentIndex
+   */
+  describe("getComponentIndex", function(){
+    /**
+     * ## The CDF framework # getComponentIndex returns -1 if a string is provided with a name of an unexisting component
+     */
+    it("returns -1 if a string is provided with a name of an unexisting component",function(done) {
+      expect(myDashboard.getComponentIndex("unexistingComponent")).toEqual(-1);
+      done();
+    });
+    /**
+     * ## The CDF framework # getComponentIndex returns the number itself when a number is provided
+     */
+    it("returns the number itself when a number is provided",function(done) {
+      expect(myDashboard.getComponentIndex(1)).toEqual(1);
+      done();
+    });
+    /**
+     * ## The CDF framework # getComponentIndex returns the index of a component in the components array if the component is provided
+     */
+    it("returns the index of a component in the components array if the component is provided",function(done) {
+      var tmp = myDashboard.components[0];
+      expect(myDashboard.getComponentIndex(tmp)).toEqual(0);
+      done();
+    });
+    /**
+     * ## The CDF framework # getComponentIndex returns the index of a component in the components array when the component's name is provided
+     */
+    it("returns the index of a component in the components array when the component's name is provided",function(done) {
+      var tmp = myDashboard.components[1];
+      expect(myDashboard.getComponentIndex(tmp.name)).toEqual(1);
+      done();
+    });
+  });
+  /**
+   * ## The CDF framework # getComponentByName
+   */
+  describe("getComponentByName", function(){
+    /**
+     * ## The CDF framework # getComponentByName returns undefined if null is provided
+     */
+    it("returns undefined if null is provided",function(done) {
+      expect(myDashboard.getComponentByName(null)).toEqual(undefined);
+      done();
+    });
+    /**
+     * ## The CDF framework # getComponentByName returns undefined if undefined is provided
+     */
+    it("returns undefined if undefined is provided",function(done) {
+      expect(myDashboard.getComponentByName(undefined)).toEqual(undefined);
+      done();
+    });
+    /**
+     * ## The CDF framework # getComponentByName returns undefined when an empty string is provided
+     */
+    it("returns undefined when an empty string is provided",function(done) {
+      expect(myDashboard.getComponentByName("")).toEqual(undefined);
+      done();
+    });
+    /**
+     * ## The CDF framework # getComponentByName returns the component when the component's name is provided
+     */
+    it("returns the component when the component's name is provided",function(done) {
+      var tmp = {};
+      $.extend( tmp, shouldUpdate );
+      expect(myDashboard.getComponentByName(shouldUpdate.name)).toEqual(shouldUpdate);
+      done();
+    });
+    /**
+     * ## The CDF framework # getComponentByName returns the component from the global object window when the component's name is provided and globalContext is true
+     */
+    it("returns the component from the global object window when the component's name is provided and globalContext is true",function(done) {
+      var tmp = {};
+      $.extend( tmp, shouldUpdate );
+      tmp.type = "dummy";
+      var globalContext_ = myDashboard.globalContext;
+      myDashboard.globalContext = true;
+      var tmp2 = window[shouldUpdate.name];
+      window[shouldUpdate.name] = tmp;
+      expect(myDashboard.getComponentByName(shouldUpdate.name)).toEqual(tmp);
+      expect(shouldUpdate.type).toEqual("managedFreeform");
+      expect(myDashboard.getComponentByName(shouldUpdate.name)).not.toEqual(shouldUpdate);
+      myDashboard.globalContext = globalContext_;
+      window[shouldUpdate.name] = tmp2;
+      done();
+    });
   });
   /**
    * ## The CDF framework # addComponent
@@ -161,23 +282,33 @@ describe("The CDF framework #", function() {
      * ## The CDF framework # addComponent replaces components when adding components with duplicate names
      */
     it("replaces components when adding components with duplicate names",function(done) {
-      expect(myDashboard.getComponent(shouldUpdate.name).size).toEqual("1");
-      shouldUpdate.size = "2";
-      myDashboard.addComponent(shouldUpdate);
-      expect(myDashboard.getComponent(shouldUpdate.name).size).toEqual("2");
+      var tmp = {};
+      $.extend( tmp, shouldUpdate );
+      tmp.type="dummy";
+      expect(myDashboard.getComponent(shouldUpdate.name).type).toEqual("managedFreeform");
+      myDashboard.addComponent(tmp);
+      expect(myDashboard.getComponent(shouldUpdate.name).type).toEqual("dummy");
       done();
     });
     /**
-     * ## The CDF framework # addComponent also adds component to global object `window` when globalContext is true
+     * ## The CDF framework # addComponent also adds component to global object window when globalContext is true
      */
-    it("also adds component to global object `window` when globalContext is true",function(done) {
-      var tmp = myDashboard.globalContext;
+    it("also adds component to global object window when globalContext is true",function(done) {
+      var tmp = {};
+      $.extend( tmp, shouldUpdate );
+      tmp.type="dummy";
+      var globalContext_ = myDashboard.globalContext;
       myDashboard.globalContext = true;
+      myDashboard.addComponent(tmp);
+      expect(myDashboard.getComponent(shouldUpdate.name).type).toEqual(tmp.type);
+      expect(myDashboard.getComponent(shouldUpdate.name).type).not.toEqual(shouldUpdate.type);
+      expect(myDashboard.components[myDashboard.getComponentIndex(shouldUpdate.name)]).toEqual(tmp);
+      expect(myDashboard.components[myDashboard.getComponentIndex(shouldUpdate.name)]).not.toEqual(shouldUpdate);
+      expect(window[shouldUpdate.name]).toEqual(tmp);
+      expect(window[shouldUpdate.name]).not.toEqual(shouldUpdate);
+      myDashboard.globalContext = globalContext_;
+      //remove tmp and add shouldUpdate
       myDashboard.addComponent(shouldUpdate);
-      expect(myDashboard.getComponent(shouldUpdate.name).size).toEqual("2");
-      expect(myDashboard.components[myDashboard.getComponentIndex(shouldUpdate.name)]).toEqual(shouldUpdate);
-      expect(window[shouldUpdate.name]).toEqual(shouldUpdate);
-      myDashboard.globalContext = tmp;
       done();
     });
   });
@@ -186,9 +317,34 @@ describe("The CDF framework #", function() {
    */
   describe("removeComponent", function(){
     /**
-     * ## The CDF framework # removeComponent removes components with the same name, if the component object or name is provided
+     * ## The CDF framework # removeComponent returns undefined when removing a component that doesn't exist
      */
-    it("removes components with the same name, if the component object or name is provided",function(done) {
+    it("returns undefined when removing a component that doesn't exist",function(done) {
+      expect(myDashboard.removeComponent("fakeComponent")).toEqual(undefined);
+      done();
+    });
+    /**
+     * ## The CDF framework # removeComponent returns undefined when removing a component at an invalid index of Dashboards.components
+     */
+    it("returns undefined when removing a component at an invalid index of Dashboards.components",function(done) {
+      var invalidIndex = Dashboards.components.length;
+      expect(myDashboard.removeComponent(invalidIndex)).toEqual(undefined);
+      done();
+    });
+    /**
+     * ## The CDF framework # removeComponent returns undefined when removing a component that doesn't exist in Dashboards.components
+     */
+    it("returns undefined when removing a component that doesn't exist in Dashboards.components",function(done) {
+      var tmp = {};
+      $.extend( tmp, shouldUpdate );
+      tmp.name="unexistingComponent";
+      expect(myDashboard.removeComponent(tmp)).toEqual(undefined);
+      done();
+    });
+    /**
+     * ## The CDF framework # removeComponent removes components with the same name, if the component object with property name is provided
+     */
+    it("removes a component with the same name as the component object with property name provided",function(done) {
       expect(myDashboard.getComponent(shouldUpdate)).toEqual(shouldUpdate);
       expect(myDashboard.getComponent(shouldUpdate.name)).toEqual(shouldUpdate);
       expect(myDashboard.removeComponent(shouldUpdate)).toEqual(shouldUpdate);
@@ -196,6 +352,13 @@ describe("The CDF framework #", function() {
       expect(myDashboard.getComponent(shouldUpdate)).toEqual(undefined);
       expect(myDashboard.getComponent(shouldUpdate.name)).toEqual(undefined);
       myDashboard.addComponent(shouldUpdate);
+      done();
+    });
+    /**
+     * ## The CDF framework # removeComponent removes a component with the same name as the name provided
+     */
+    it("removes a component with the same name as the name provided",function(done) {
+      expect(myDashboard.getComponentIndex(shouldUpdate)).not.toEqual(-1);
       expect(myDashboard.getComponent(shouldUpdate)).toEqual(shouldUpdate);
       expect(myDashboard.getComponent(shouldUpdate.name)).toEqual(shouldUpdate);
       expect(myDashboard.removeComponent(shouldUpdate.name)).toEqual(shouldUpdate);
@@ -206,19 +369,18 @@ describe("The CDF framework #", function() {
       done();
     });
     /**
-     * ## The CDF framework # removeComponent also removes a component from the global object `window` when globalContext is true
+     * ## The CDF framework # removeComponent also removes a component from the global object window when globalContext is true
      */
-    it("also removes a component from the global object `window` when globalContext is true",function(done) {
-      var tmp = myDashboard.globalContext;
+    it("removes a component from the global object window when globalContext is true",function(done) {
+      var globalContext_ = myDashboard.globalContext;
       myDashboard.globalContext = true;
       myDashboard.addComponent(shouldUpdate);
-      expect(myDashboard.getComponent(shouldUpdate.name).size).toEqual("2");
       expect(window[shouldUpdate.name]).toEqual(shouldUpdate);
+      expect(myDashboard.components[myDashboard.getComponentIndex(shouldUpdate.name)]).toEqual(shouldUpdate);
       myDashboard.removeComponent(shouldUpdate);
-      expect(myDashboard.getComponent(shouldUpdate.name)).toEqual(undefined);
-      expect(myDashboard.components[myDashboard.getComponentIndex(shouldUpdate.name)]).toEqual(undefined);
       expect(window[shouldUpdate.name]).toEqual((undefined));
-      myDashboard.globalContext = tmp;
+      expect(myDashboard.components[myDashboard.getComponentIndex(shouldUpdate.name)]).toEqual(undefined);
+      myDashboard.globalContext = globalContext_;
       done();
     });
 


### PR DESCRIPTION
...he same name, if an object is passed

```
- Dashboards.removeComponent removes components when a string or and object is passed
- Dashboards.removeComponent also removes the component from the global window object if globalContext is true
```

[CDF-351] - Dashboards.addComponents does not check for components with the same name
    - Dashboards.addComponents replaces components with the same names as the new
    - Dashboards.addComponents also adds the components to the global window object if globalContext is true
[CDF-348] - Dashboards.getComponent[ByName] should not use eval, for consistency with .getParameterValue
    - Dashboards.getComponentByName returns the object from the global window object if globalContext is true, or from Dashboards.components otherwise
