### PR TITLE
[CDF-356] - in biserver 4.8 markers don't show in MapComponents/MapCompo...

### DIFF
--- a/cdf-pentaho/solution/plugin-samples/pentaho-cdf/30-documentation/30-component_reference/30-map/31-MapComponent Custom Map/template.html
+++ b/cdf-pentaho/solution/plugin-samples/pentaho-cdf/30-documentation/30-component_reference/30-map/31-MapComponent Custom Map/template.html
@@ -136,7 +136,7 @@ mapComponent =
 	  name: "mapComponent",
 	  type: "map",
 	  solution: "plugin-samples",
-	  path: "cdf-samples/20-samples/map_dashboard",
+	  path: "pentaho-cdf/20-samples/map_dashboard",
 	  action: "GetPoints.xaction",
 	  parameters:[],
 	  listeners:[],


### PR DESCRIPTION
...nent (Custom map sample)

```
- fixed bug in component path that was making markers not load into MapComponent
```
