### PR TITLE
[CDF-353] - Dashboards._isParameterInModel should look for the parameter...

### DIFF
--- a/cdf-core/cdf/js/Dashboards.Main.js
+++ b/cdf-core/cdf/js/Dashboards.Main.js
@@ -1091,60 +1091,86 @@ Dashboards._getParameterStore = function(){
 /**
  * Verifies if a parameter is available in the Parameter Model
  *
- * @param name of the parameter
- * @returns boolean
+ * @param {string} name of the parameter
+ * @returns {boolean}
  * @private
  */
 Dashboards._isParameterInModel = function(name){
-  return this.parameterModel.attributes.hasOwnProperty(name) ;
+  return this._getValueFromContext(this._getParameterStore(), name) !== undefined;
 };
 
 /**
- * Gets the value from a context o from the property with a given path
+ * Gets the value of a path in a given object.
  *
- * @param o the context of the assignment
- * @param path the path of the property
- * @returns the value of the property
+ * @param {Object} o the context object
+ * @param {string|Array.<string>} path the path of the property
+ * @returns {*} the value of the property, if the path is present in <i>o</i>, or <tt>undefined</tt>, otherwise.
  * @private
  */
 Dashboards._getValueFromContext = function(o, path) {
-  if (!o) return; //undefined
-  if (null != path) {
-    var parts = (path instanceof Array) ? path : path.split("."), L = parts.length;
-    if (L) for (var i = 0; L > i; ) {
-      var part = parts[i++], value = o[part];
-      if (null == value) {
-        return; //the path requested is undefined
-      }
+  if(!o) return;
+
+  if(path != null) {
+    var parts, L;
+
+    if(path instanceof Array) {
+      parts = path;
+    } else {
+      if(path.indexOf('.') < 0) return o[path];
+
+      parts = path.split(".");
+    } 
+    L = parts.length;
+
+    for(var i = 0; i < L; i++) {
+      //if(!(o instanceof Object) return; // not an object
+      if(!o) return; // more efficient approximation
+
+      var part = parts[i],
+          value = o[part];
+      if(value === undefined) return;
+      
       o = value;
     }
   }
+
   return o;
 };
 
 /**
- * Sets a property path in a context o with v as value
+ * Sets a property path in a context <i>o</i> with value <i>v</i>
  *
- * @param o the context of the assignment
- * @param path the path of the property
- * @param v the value of the property
- * @returns the value of the property assigned
+ * @param {Object} o the context object
+ * @param {string|Array.<string>} path the path of the property
+ * @param {*} v the value of the property
+ * @returns the context object <i>o</i> or undefined
  * @private
  */
 Dashboards._setValueInContext = function(o, path, v) {
-  if (o && null != path) {
-    var parts = (path instanceof Array) ? path : path.split(".");
-    if (parts.length) {
-      var pLast = parts.pop();
-      o = this._getValueFromContext(o, parts);
-      if(o) o[pLast] = v;
+  if(!o || path == null || v === undefined) return; // undefined
+
+  var parts, pLast;
+  if(path instanceof Array) {
+    parts = path;
+    pLast = parts.pop();
+  } else {
+    if(path.indexOf(".") < 0) {
+      o[path] = v;
+      return o;
     }
+
+    parts = path.split(".");
+    pLast = parts.pop();
   }
+
+  o = this._getValueFromContext(o, parts);
+  if(o) o[pLast] = v;
+
   return o;
 };
 
 /**
- * Adds a parameter new parameter to the parameter module.
+ * Adds a new parameter to the parameter module.
  * Receives a parameter name and an initial value, that will be used if the parameter is
  * not available in the parameter model. Otherwise, the getParameterValue return is used
  *
@@ -1161,23 +1187,34 @@ Dashboards.addParameter = function(name, initValue){
 };
 
 Dashboards.getParameterValue = dash.getParam = function (parameterName) {
-  var parameterStore = this._getParameterStore();
-  return this._getValueFromContext(parameterStore, parameterName);
+  return this._getValueFromContext(this._getParameterStore(), parameterName);
 };
 
+/* Sets the value of a parameter if it's name is not undefined and is not an empty string. The
+ * parameter will also not be set when using a composed path that lacks more than the last
+ * parameter (eg: when setting parameter <i>dash.obj.prop</i> if <i>dash.obj</i> doesn't exist undefined will be returned).
+ *
+ * @param parameterName the name of the parameter
+ * @param parameterValue the value of the parameter
+ * @isNotified the value of notify passed to the Backbone Model setter
+ * @returns the new value of the parameter or undefined
+ */
 Dashboards.setParameter = dash.setParam = function(parameterName, parameterValue, isNotified) {
-  if(parameterName == undefined || parameterName == "undefined"){
-    this.log('Dashboards.setParameter: trying to set undefined!!','warn');
+  if(parameterName == undefined || parameterName == "undefined" || parameterName == ""){
+    this.log('Dashboards.setParameter: trying to set undefined or empty string as parameter name!!','warn');
     return;
   }
-  var parameterStore = this._getParameterStore();
+  var value;
   if(!this.globalContext && this.escapeParameterValues){
-    this._setValueInContext(parameterStore, parameterName, encode_prepare_arr(parameterValue));
+    value = encode_prepare_arr(parameterValue);
   } else {
-    this._setValueInContext(parameterStore, parameterName, parameterValue);
+    value = parameterValue;
   }
-  this.parameterModel.set(parameterName,parameterValue,{notify:isNotified});
-  this.persistBookmarkables(parameterName);
+  if(this._setValueInContext(this._getParameterStore(), parameterName, value) !== undefined){
+    this.parameterModel.set(parameterName,value,{notify:isNotified});
+    this.persistBookmarkables(parameterName);
+    return value;
+  }
 };
 
 

--- a/cdf-core/test-js/core-spec.js
+++ b/cdf-core/test-js/core-spec.js
@@ -154,9 +154,14 @@ describe("The CDF framework #", function() {
     testSimpleAddParameter("numberParam", 1, 2);
     testSimpleAddParameter("stringParam", "test", "testtest");
     testSimpleAddParameter("booleanParam", true, false);
-    testSimpleAddParameter("undefinedParam", undefined, "test");
+    testSimpleAddParameter("nullParam", null, "test");
     testSimpleAddParameter("arrayParam", ["test1", "test2"], ["test3", "test4"]);
     testSimpleAddParameter("objectParam1", {a: 1, b: 2}, {});
+
+    myDashboard.addParameter("undefinedParam", undefined);
+    expect(myDashboard.getParameterValue("undefinedParam")).toEqual(undefined);
+    myDashboard.addParameter("undefinedParam", 123);
+    expect(myDashboard.getParameterValue("undefinedParam")).toEqual(123);
 
     var func1 = function(){var v=0;return v;};
     testFunctionAddParameter("functionParam", func1, func1.toString(), func1());
@@ -209,9 +214,14 @@ describe("The CDF framework #", function() {
     testSimpleAddParameter("Dashboards.storage.numberParam", 1, 2);
     testSimpleAddParameter("Dashboards.storage.stringParam", "test", "testtest");
     testSimpleAddParameter("Dashboards.storage.booleanParam", true, false);
-    testSimpleAddParameter("Dashboards.storage.undefinedParam", undefined, "test");
+    testSimpleAddParameter("Dashboards.storage.nullParam", null, "test");
     testSimpleAddParameter("Dashboards.storage.arrayParam", ["test1", "test2"], ["test3", "test4"]);
     testSimpleAddParameter("Dashboards.storage.objectParam1", {a: 1, b: 2}, {});
+
+    myDashboard.addParameter("Dashboards.storage.undefinedParam", undefined);
+    expect(myDashboard.getParameterValue("Dashboards.storage.undefinedParam")).toEqual(undefined);
+    myDashboard.addParameter("Dashboards.storage.undefinedParam", 123);
+    expect(myDashboard.getParameterValue("Dashboards.storage.undefinedParam")).toEqual(123);
 
   });
   /**
@@ -219,17 +229,17 @@ describe("The CDF framework #", function() {
    */
   it("Sets parameters", function() {
     /**
-     * Tests the addParameter call. The second value will never be assigned because the parameter is already defined
+     * Tests the setParameter call. The second value, when not undefined, will override the previous one
      *
      * @param paramName
      * @param firstValue
      * @param secondValue
      */
     var testSimpleSetParameter = function(paramName, firstValue, secondValue){
-      myDashboard.addParameter(paramName,firstValue);
+      myDashboard.setParameter(paramName,firstValue);
       testSimpleParameter(paramName, firstValue);
-      myDashboard.addParameter(paramName,secondValue);
-      testSimpleParameter(paramName, firstValue);
+      myDashboard.setParameter(paramName,secondValue);
+      testSimpleParameter(paramName, secondValue);
     };
     /**
      * Tests a function parameter, if its body and return value are the same
@@ -240,16 +250,27 @@ describe("The CDF framework #", function() {
      * @param returnValue
      */
     var testFunctionSetParameter = function(parameterName, func, funcToString, returnValue){
-      myDashboard.addParameter(parameterName, func);
+      myDashboard.setParameter(parameterName, func);
       testFunctionParameter(parameterName, func, funcToString, returnValue);
     };
 
     testSimpleSetParameter("numberParam", 1, 2);
     testSimpleSetParameter("stringParam", "test", "testtest");
     testSimpleSetParameter("booleanParam", true, false);
-    testSimpleSetParameter("undefinedParam", undefined, "test");
     testSimpleSetParameter("arrayParam", ["test1", "test2"], ["test3", "test4"]);
     testSimpleSetParameter("objectParam1", {a: 1, b: 2}, {});
+
+    testSimpleSetParameter("nullParam", null, "test");
+    expect(myDashboard.parameterModel.get("nullParam")).toEqual("test");
+    testSimpleSetParameter("nullParam", "test", null);
+    expect(myDashboard.parameterModel.get("nullParam")).toEqual(null);
+
+    myDashboard.setParameter("undefinedParam2", 123);
+    expect(myDashboard.getParameterValue("undefinedParam2")).toEqual(123);
+    expect(myDashboard.parameterModel.get("undefinedParam2")).toEqual(123);
+    myDashboard.setParameter("undefinedParam2", undefined);
+    expect(myDashboard.getParameterValue("undefinedParam2")).toEqual(123);
+    expect(myDashboard.parameterModel.get("undefinedParam2")).toEqual(123);
 
     var func1 = function(){var v=0;return v;};
     testFunctionSetParameter("functionParam", func1, func1.toString(), func1());
@@ -302,10 +323,48 @@ describe("The CDF framework #", function() {
     testSimpleSetParameter("Dashboards.storage.numberParam", 1, 2);
     testSimpleSetParameter("Dashboards.storage.stringParam", "test", "testtest");
     testSimpleSetParameter("Dashboards.storage.booleanParam", true, false);
-    testSimpleSetParameter("Dashboards.storage.undefinedParam", undefined, "test");
+    testSimpleSetParameter("Dashboards.storage.nullParam", null, "test");
+    testSimpleSetParameter("Dashboards.storage.nullParam", "test", null);
     testSimpleSetParameter("Dashboards.storage.arrayParam", ["test1", "test2"], ["test3", "test4"]);
     testSimpleSetParameter("Dashboards.storage.objectParam1", {a: 1, b: 2}, {});
 
+    myDashboard.setParameter("Dashboards.storage.undefinedParam2", 123);
+    expect(myDashboard.getParameterValue("Dashboards.storage.undefinedParam2")).toEqual(123);
+    expect(myDashboard.parameterModel.get("Dashboards.storage.undefinedParam2")).toEqual(123);
+    myDashboard.setParameter("Dashboards.storage.undefinedParam2", undefined);
+    expect(myDashboard.getParameterValue("Dashboards.storage.undefinedParam2")).toEqual(123);
+    expect(myDashboard.parameterModel.get("Dashboards.storage.undefinedParam2")).toEqual(123);
+
+  });
+  /**
+   * ## The CDF framework # _isParameterInModel
+   */
+  describe("The CDF framework # _isParameterInModel", function() {
+    /**
+     * ## The CDF framework # Looks for parameters in the correct context, `window` when `Dashboards.globalContext` is true
+     */
+    it("Looks for parameters in the correct context, `window` when `Dashboards.globalContext` is true", function() {
+      myDashboard.globalContext = true;
+      expect(myDashboard._isParameterInModel("contextParam")).toEqual(false);
+      myDashboard.setParameter("contextParam",1);
+      expect(window["contextParam"]).toEqual(1);
+      expect(myDashboard.parameters["contextParam"]).toEqual(undefined);
+      expect(myDashboard.getParameterValue("contextParam")).toEqual(1);
+      expect(myDashboard._isParameterInModel("contextParam")).toEqual(true);
+    });
+    /**
+     * ## The CDF framework # Looks for parameters in the correct context, `Dashboards.parameters` when `Dashboards.globalContext` is false
+     */
+    it("Looks for parameters in the correct context, `Dashboards.parameters` when `Dashboards.globalContext` is false", function() {
+      myDashboard.globalContext = false;
+      expect(myDashboard._isParameterInModel("contextParam2")).toEqual(false);
+      myDashboard.setParameter("contextParam2",2);
+      expect(window["contextParam2"]).toEqual(undefined);
+      expect(myDashboard.parameters["contextParam2"]).toEqual(2);
+      expect(myDashboard.getParameterValue("contextParam2")).toEqual(2);
+      expect(myDashboard._isParameterInModel("contextParam2")).toEqual(true);
+      myDashboard.globalContext = true;
+    });
   });
   /**
    * ## The CDF framework # Syncs parameters


### PR DESCRIPTION
... in the correct context
- Dashboards._isParameterInModel now looks for the parameter in the correct context
- Parameters with null value are allowed and parameters with undefined value are overridable by addParameter
- Dashboards.setParameter doesn't allow to set a parameter with an empty string as it's name
- Dashboards.parameterModel and Dashboards.persistBookmarkables are only called by Dashboards.setParameter if the parameter is set in the target context object
- Reviewed and added tests for Dashboards.addParameter and Dashboards.setParameter
