### PR TITLE
[CDF-370] - Fixed bug introduced in b639889e3906513c4de69dde72896d605ade...

### DIFF
--- a/cdf-core/cdf/js/queries/coreQueries.js
+++ b/cdf-core/cdf/js/queries/coreQueries.js
@@ -345,21 +345,35 @@
           params = $.extend( {}, cachedParams , overrides);
 
       _.each( params , function (value, name) {
-        value = Dashboards.getParameterValue(value);
-          if (_.isObject(value)){
-              // kettle does not handle arrays natively,
-              // nor does it interpret multiple parameters with the same name as elements of an array,
-              // nor does CPK do any sort of array handling.
-              // A stringify ensures the array is passed as a string, that can be parsed using kettle.
-              value = JSON.stringify(value);
-              // Another option would be to add futher:
-              // value = value.split('],').join(';').split('[').join('').split(']').join('');
-              // which transforms [[0,1],[2,3]] into "0,1;2,3"
+        var paramValue;
+        try {
+          paramValue = Dashboards.getParameterValue(value);
+        } catch( e ) {
+          if(!_.isObject(value) || _.isFunction(value)) {
+            printValue = value;
+          } else {
+            printValue = JSON.stringify(value);
           }
-          if (typeof value == 'function') {
-              value = value();
-          }
-        queryDefinition['param' + name] = value;
+          Dashboards.log("BuildQueryDefinition detected static parameter " + name + "=" + printValue + ". " +
+              "The parameter will be used as value instead its value obtained from getParameterValue");
+          paramValue = value;
+        }
+        if( paramValue === undefined) {
+          paramValue = value;
+        }
+        if (_.isFunction(paramValue)){
+          paramValue = paramValue();
+        } else if (_.isObject(paramValue)){
+          // kettle does not handle arrays natively,
+          // nor does it interpret multiple parameters with the same name as elements of an array,
+          // nor does CPK do any sort of array handling.
+          // A stringify ensures the array is passed as a string, that can be parsed using kettle.
+          paramValue = JSON.stringify(paramValue);
+          // Another option would be to add futher:
+          // value = value.split('],').join(';').split('[').join('').split(']').join('');
+          // which transforms [[0,1],[2,3]] into "0,1;2,3"
+        }
+        queryDefinition['param' + name] = paramValue;
       });
 
       return queryDefinition;
@@ -429,16 +443,32 @@
           params = $.extend( {}, cachedParams , overrides);
 
       _.each( params , function (value, name) {
-        value = Dashboards.getParameterValue(value);
-        if($.isArray(value) && value.length == 1 && ('' + value[0]).indexOf(';') >= 0){
+        var paramValue;
+        try {
+          paramValue = Dashboards.getParameterValue(value);
+        } catch( e ) {
+          var printValue = "";
+          if(!_.isObject(value) || _.isFunction(value)) {
+            printValue = value;
+          } else {
+            printValue = JSON.stringify(value);
+          }
+          Dashboards.log("BuildQueryDefinition detected static parameter " + name + "=" + printValue + ". " +
+              "The parameter will be used instead the parameter value");
+          paramValue = value;
+        }
+        if( paramValue === undefined) {
+          paramValue = value;
+        }
+        if($.isArray(paramValue) && paramValue.length == 1 && ('' + paramValue[0]).indexOf(';') >= 0){
           //special case where single element will wrongly be treated as a parseable array by cda
-          value = doCsvQuoting(value[0],';');
+          paramValue = doCsvQuoting(paramValue[0],';');
         }
         //else will not be correctly handled for functions that return arrays
-        if (typeof value == 'function') {
-          value = value();
+        if (typeof paramValue == 'function') {
+          paramValue = paramValue();
         }
-        queryDefinition['param' + name] = value;
+        queryDefinition['param' + name] = paramValue;
       });
       queryDefinition.path = this.getOption('file');
       queryDefinition.dataAccessId = this.getOption('id');

--- a/cdf-core/test-js/query-spec.js
+++ b/cdf-core/test-js/query-spec.js
@@ -36,4 +36,97 @@ describe("The Query class #", function() {
     expect(settings.type).toEqual("GET");
     expect(settings.async).toBeTruthy();
   });
+
+
+  it("Allows static params in query parameters", function() {
+    var CpkQuery = new Query({
+      endpoint: "getPluginMetadata",
+      pluginId: "sparkl",
+      stepName: "OUTPUT",
+      kettleOutput: "Inferred",
+      queryType: "cpk"
+    });
+
+    var CdaQuery = new Query({
+      dataAccessId: "foo",
+      path:"bar"
+    });
+
+    var params = {
+      myParam1: true,
+      myParam2: "'test'",
+      myParam3: "test",
+      myParam4: "['test1', 'test2']",
+      myParam5: "[test1, test2]",
+      myParam6: undefined,
+      myParam7: function() {
+        return "myParam8FuncReturn"
+      },
+      myParam8: 1,
+      myParam9: ["test1"],
+      myParam10: [1, 2, 3],
+      myParam11: {
+        test1: "test1",
+        test2: "test2"
+      },
+      myParam12: ["test1;test2;test3"]
+    };
+
+    var cpkQueryDefinition = CpkQuery.buildQueryDefinition(params);
+
+    expect(cpkQueryDefinition.hasOwnProperty('parammyParam1')).toBe(true);
+    expect(cpkQueryDefinition.hasOwnProperty('parammyParam2')).toBe(true);
+    expect(cpkQueryDefinition.hasOwnProperty('parammyParam3')).toBe(true);
+    expect(cpkQueryDefinition.hasOwnProperty('parammyParam4')).toBe(true);
+    expect(cpkQueryDefinition.hasOwnProperty('parammyParam5')).toBe(true);
+    expect(cpkQueryDefinition.hasOwnProperty('parammyParam6')).toBe(false);
+    expect(cpkQueryDefinition.hasOwnProperty('parammyParam7')).toBe(true);
+    expect(cpkQueryDefinition.hasOwnProperty('parammyParam8')).toBe(true);
+    expect(cpkQueryDefinition.hasOwnProperty('parammyParam9')).toBe(true);
+    expect(cpkQueryDefinition.hasOwnProperty('parammyParam10')).toBe(true);
+    expect(cpkQueryDefinition.hasOwnProperty('parammyParam11')).toBe(true);
+    expect(cpkQueryDefinition.hasOwnProperty('parammyParam12')).toBe(true);
+
+    expect(cpkQueryDefinition.parammyParam1).toBe(true);
+    expect(cpkQueryDefinition.parammyParam2).toBe("'test'");
+    expect(cpkQueryDefinition.parammyParam3).toBe("test");
+    expect(cpkQueryDefinition.parammyParam4).toBe("['test1', 'test2']");
+    expect(cpkQueryDefinition.parammyParam5).toBe("[test1, test2]");
+    expect(cpkQueryDefinition.parammyParam7).toBe("myParam8FuncReturn");
+    expect(cpkQueryDefinition.parammyParam8).toBe(1);
+    expect(cpkQueryDefinition.parammyParam9).toBe('["test1"]');
+    expect(cpkQueryDefinition.parammyParam10).toBe('[1,2,3]');
+    expect(cpkQueryDefinition.parammyParam11).toBe('{"test1":"test1","test2":"test2"}');
+    expect(cpkQueryDefinition.parammyParam12).toBe('["test1;test2;test3"]');
+
+    var cdaQueryDefinition = CdaQuery.buildQueryDefinition(params);
+
+    expect(cdaQueryDefinition.hasOwnProperty('parammyParam1')).toBe(true);
+    expect(cdaQueryDefinition.hasOwnProperty('parammyParam2')).toBe(true);
+    expect(cdaQueryDefinition.hasOwnProperty('parammyParam3')).toBe(true);
+    expect(cdaQueryDefinition.hasOwnProperty('parammyParam4')).toBe(true);
+    expect(cdaQueryDefinition.hasOwnProperty('parammyParam5')).toBe(true);
+    expect(cdaQueryDefinition.hasOwnProperty('parammyParam6')).toBe(false);
+    expect(cdaQueryDefinition.hasOwnProperty('parammyParam7')).toBe(true);
+    expect(cdaQueryDefinition.hasOwnProperty('parammyParam8')).toBe(true);
+    expect(cdaQueryDefinition.hasOwnProperty('parammyParam9')).toBe(true);
+    expect(cdaQueryDefinition.hasOwnProperty('parammyParam10')).toBe(true);
+    expect(cdaQueryDefinition.hasOwnProperty('parammyParam11')).toBe(true);
+    expect(cdaQueryDefinition.hasOwnProperty('parammyParam12')).toBe(true);
+
+    expect(cdaQueryDefinition.parammyParam1).toBe(true);
+    expect(cdaQueryDefinition.parammyParam2).toBe("'test'");
+    expect(cdaQueryDefinition.parammyParam3).toBe("test");
+    expect(cdaQueryDefinition.parammyParam4).toBe("['test1', 'test2']");
+    expect(cdaQueryDefinition.parammyParam5).toBe("[test1, test2]");
+    expect(cdaQueryDefinition.parammyParam7).toBe("myParam8FuncReturn");
+    expect(cdaQueryDefinition.parammyParam8).toBe(1);
+    expect(cdaQueryDefinition.parammyParam9[0]).toBe('test1');
+    expect(cdaQueryDefinition.parammyParam10[0]).toBe(1);
+    expect(cdaQueryDefinition.parammyParam10[1]).toBe(2);
+    expect(cdaQueryDefinition.parammyParam10[2]).toBe(3);
+    expect(cdaQueryDefinition.parammyParam11.test1).toBe('test1');
+    expect(cdaQueryDefinition.parammyParam11.test2).toBe('test2');
+    expect(cdaQueryDefinition.parammyParam12).toBe('"test1;test2;test3"');
+  });
 });


### PR DESCRIPTION
...0411 with the parameter get and set revision. This fix removed the ability to pass as query arguments static values. Introduced a check on buildQueryDefinition for cda and cpk.

Also, fixed bug where functions not being evaluated on cpk queries due to _isObject = true if the given object is a function.
Added unit tests for the fix
