### PR TITLE
[CDF-408] Run multiple queries in parallel in a CDE dashboard

### DIFF
--- a/cdf-core/cdf/js/Dashboards.Main.js
+++ b/cdf-core/cdf/js/Dashboards.Main.js
@@ -1016,7 +1016,7 @@ Dashboards.othersAwaitExecution = function( tiers , current ) {
 
     return false; // no other components await execution
 
-  } else if( componentsToUpdate.priority > current.priority ) {
+  } else if( parseInt( componentsToUpdate.priority ) > parseInt( current.priority ) ) {
 
     // recall: 1 - utmost priority , 999999 - lowest priority
     // those who await execution are lower in priority that the current component
@@ -1080,7 +1080,7 @@ Dashboards.updateAll = function(components) {
     if( othersAwaitExecution ){ 
       var tiers = this.updating.tiers;
       tiers[updating.priority] = _.difference( tiers[updating.priority], updating.components );
-      var toUpdate = this.getFirstTier( tiers ); 
+      toUpdate.components = _.union( tiers[updating.priority] , this.getFirstTier( tiers ).components );
     }
 
     this.updating.current = toUpdate;

--- a/cdf-core/test-js/paralel-query-calls-spec.js
+++ b/cdf-core/test-js/paralel-query-calls-spec.js
@@ -1,148 +1,395 @@
 /**
  * ## Paralel query calls #
  */
-describe("Component Samples with paralel Dashboards.updateComponent #", function() {
+describe("Dashboards.othersAwaitExecution behaviour unit testing #", function() {
 
-  TestQueryUnmanagedComponent = HelloQueryUnmanagedComponent.extend({
+  var mockDashboard = _.extend({},Dashboards);
 
-    // mock the query call: response is delayed for 1000 millis
-    triggerQuery: function( queryDef, callback, userQueryOptions ) {
-      myDashboard.runningCalls++;
-     
-      var mockTriggerQuery = function() {
-         // query response has arrived, lets decrement the runningCalls and return a JSON result 
-         myDashboard.runningCalls--;
-         return JSON.parse('{"result":true,"count":0}');
-      };
-
-      setTimeout( mockTriggerQuery, 3000 /* 3000 millis delay for query response */ );
+  // component<number>priority<value>
+  var comp1priority5 = window.basic = {
+    updateFlag: 0,
+    preExecutionFlag: 0,
+    postExecutionFlag: 0,
+    name: "comp1priority5",
+    type: "freeform",
+    htmlObject: 'html-obj',
+    priority: 5,
+    executeAtStart: false,
+    startTimer: function() {},
+    on: function() {},
+    off: function() {},
+    trigger: function( trigger, obj, bool ) { 
+      if( trigger.indexOf('cdf:preExecution') > 0 ){ this.preExecution(); } 
+      if( trigger.indexOf('cdf:postExecution') > 0 ){ this.postExecution(); }
+    },
+    preExecution: function() { this.preExecutionFlag = 1; return true; },
+    update: function() { this.updateFlag = 1; },
+    postExecution: function() { this.postExecutionFlag = 1; },
+    reset: function(){
+      this.preExecutionFlag = 0;
+      this.updateFlag = 0;
+      this.postExecutionFlag = 0;
     }
-  });
-  
-  var myDashboard = _.extend({},Dashboards);
-  myDashboard.logLifecycle = true;
+  };
 
-  var mainComponent = window.mhello = {
-    name: "mainComponent",
-    type: "HelloBase",
+  // component<number>priority<value>
+  var comp2priority5 = window.basic = {
+    updateFlag: 0,
+    preExecutionFlag: 0,
+    postExecutionFlag: 0,
+    name: "comp2priority5",
+    type: "freeform",
+    htmlObject: 'html-obj',
+    priority: 5,
     testFlag: 0,
-    silent: false,
-    htmlObject: 'mhello',
-    executeAtStart: false,
-    clickAction: function(){
-      Dashboards.fireChange( 'component1' );
-      Dashboards.fireChange( 'component2' );
-      Dashboards.fireChange( 'component3' );
+    executeAtStart: true,
+    startTimer: function() {},
+    on: function() {},
+    off: function() {},
+    trigger: function( trigger, obj, bool ) {
+      if( trigger.indexOf('cdf:preExecution') > 0 ){ this.preExecution(); } 
+      if( trigger.indexOf('cdf:postExecution') > 0 ){ this.postExecution(); } 
+    },
+    preExecution: function() { this.preExecutionFlag = 1; return true; },
+    update: function() { this.updateFlag = 1; },
+    postExecution: function() { this.postExecutionFlag = 1; },
+    reset: function(){
+      this.preExecutionFlag = 0;
+      this.updateFlag = 0;
+      this.postExecutionFlag = 0;
     }
   };
 
-  var component1 = window.uquery = {
-    name: "component1",
-    type: "TestQueryUnmanaged",
-    silent: false,
-    htmlObject: 'uquery', 
-    priority: 5,
-    listeners: ["component1"],
-    parameters: [["component1","component1"]],
-    executeAtStart: false,
-    queryDefinition: { path: "", dataAccessId: "component1" },
-    preExecution: function(){ 
-      return true; 
+  // component<number>priority<value>
+  var comp3priority10 = window.basic = {
+    updateFlag: 0,
+    preExecutionFlag: 0,
+    postExecutionFlag: 0,
+    name: "comp3priority10",
+    type: "freeform",
+    htmlObject: 'html-obj',
+    priority: 10,
+    testFlag: 0,
+    executeAtStart: true,
+    on: function() {},
+    off: function() {},  
+    trigger: function( trigger, obj, bool ) {
+      if( trigger.indexOf('cdf:preExecution') > 0 ){ this.preExecution(); } 
+      if( trigger.indexOf('cdf:postExecution') > 0 ){ this.postExecution(); } 
     },
-    postExecution: function(){}
+    startTimer: function() {},
+    preExecution: function() { this.preExecutionFlag = 1; return true; },
+    update: function() { this.updateFlag = 1; },
+    postExecution: function() { this.postExecutionFlag = 1; },
+    reset: function(){
+      this.preExecutionFlag = 0;
+      this.updateFlag = 0;
+      this.postExecutionFlag = 0;
+    }
   };
 
-  var component2 = window.uquery = { 
-    name: "component2",
-    type: "TestQueryUnmanaged",
-    silent: false,
-    htmlObject: 'uquery',
-    priority: 5,
-    listeners: ["component2"],
-    parameters: [["component2","component2"]],
-    executeAtStart: false,
-    queryDefinition: { path: "", dataAccessId: "component2" },
-    preExecution: function(){ 
-      return true; 
-    },
-    postExecution: function(){}
-  };
+  it("Should return true when current object is comp1priority5 and updateTier array holds comp1priority5, comp2priority5 and comp3priority10", function(done){
 
-  var component3 = window.uquery = {
-    name: "component3",
-    type: "TestQueryUnmanaged",
-    silent: false,
-    htmlObject: 'uquery',
-    priority: 5,
-    listeners: ["component3"],
-    parameters: [["component3","component3"]],
-    executeAtStart: false,
-    queryDefinition: { path: "", dataAccessId: "component3" },
-    preExecution: function(){ 
-      return true; 
-    },
-    postExecution: function(){}
-  };
+    var mockUpdateTiers = { 5:  [ comp1priority5 , comp2priority5 ], 10: [ comp3priority10 ] };
 
-  var componentList = [ mainComponent, component1, component2, component3 ];
-  myDashboard.addComponents( componentList );
+    var mockUpdateCurrent = { components: [ comp1priority5  ], priority: comp1priority5.priority };
 
-  describe("Paralel query calls", function(){
-    /**
-     * ## Paralel query calls
-     */
-    it("Should trigger all component query calls immediatelly and *not* have to wait for the previous component to end", function(done){
+    var otherCompAwaitExecution = Dashboards.othersAwaitExecution( mockUpdateTiers, mockUpdateCurrent );
 
-      //update all components of this test
-
-      spyOn(component1, 'update').and.callThrough();
-      spyOn(component1, 'triggerQuery').and.callThrough();
-      spyOn(component1, 'postExecution').and.callThrough();
-
-      spyOn(component2, 'update').and.callThrough();
-      spyOn(component2, 'triggerQuery').and.callThrough();
-      spyOn(component2, 'postExecution').and.callThrough();
-
-      spyOn(component3, 'update').and.callThrough();
-      spyOn(component3, 'triggerQuery').and.callThrough();
-      spyOn(component3, 'postExecution').and.callThrough(); 
-      debugger;
-      myDashboard.finishedInit = false;
-      myDashboard.init(); 
-      myDashboard.components[ myDashboard.components.indexOf( mainComponent ) ].clickAction();
-
-      //Data To Validate 
-      var dataToValidate = function() { 
-
-        expect(component1.update.calls.count()).toEqual(1); // component1's update was triggered   
-        expect(component1.triggerQuery.calls.count()).toEqual(1); // component1's query was triggered
-
-        expect(component2.update.calls.count()).toEqual(1); // component1's update was triggered
-        expect(component2.triggerQuery.calls.count()).toEqual(1); // component2's query was triggered 
-
-        expect(component3.update.calls.count()).toEqual(1); // component1's update was triggered
-        expect(component3.triggerQuery.calls.count()).toEqual(1); // component3's query was triggered 
- 
-        // so, by this point, all components of equal priority have 
-        // been triggered, and their respective query calls have been made   
-
-        expect(myDashboard.runningCalls).toEqual(3); // how many running calls do we have (should be 3)
-        
-      }
-      setTimeout(dataToValidate, 1000);
-
-
-      var dataToValidate2 = function() { 
-
-        // let's wait 3 seconds (should be enough for all query call to have returned),
-        // and let's check how many runningCalls we have (should be zero)
-
-        expect(myDashboard.runningCalls).toEqual(0);
-        
-        done();
-      }
-      setTimeout(dataToValidate2, 3000);
-
-    });    
+    expect( otherCompAwaitExecution ).toBeTruthy();
+    done();
   });
+
+  it("Should return false when current object is comp1priority5 and comp2priority5, and updateTier array holds comp1priority5, comp2priority5 and comp3priority10", function(done){
+
+    var mockUpdateTiers = { 5:  [ comp1priority5 , comp2priority5 ], 10: [ comp3priority10 ] };
+
+    var mockUpdateCurrent = { components: [ comp1priority5 , comp2priority5 ], priority: comp1priority5.priority };
+
+    var otherCompAwaitExecution = Dashboards.othersAwaitExecution( mockUpdateTiers, mockUpdateCurrent );
+
+    expect( otherCompAwaitExecution ).not.toBeTruthy();
+    done();
+  });
+
+  it("Should return true when current object is comp3priority10, and updateTier array holds comp1priority5, comp2priority5 and comp3priority10", function(done){
+
+    var mockUpdateTiers = { 5:  [ comp1priority5 , comp2priority5 ], 10: [ comp3priority10 ] };
+
+    var mockUpdateCurrent = { components: [ comp3priority10 ], priority: comp3priority10.priority };
+
+    var otherCompAwaitExecution = Dashboards.othersAwaitExecution( mockUpdateTiers, mockUpdateCurrent );
+
+    expect( otherCompAwaitExecution ).toBeTruthy();
+    done();
+  });
+
+  it("Should go through Dashboards.updateAll handling only comp1priority5, with an empty updateTier array", function(done){
+
+    mockDashboard.updating = undefined;
+    mockDashboard.updateQueue = undefined;
+    comp1priority5.reset();
+    comp2priority5.reset();
+    comp3priority10.reset();
+
+    mockDashboard.components = [ comp1priority5, comp2priority5, comp3priority10 ];
+    
+    spyOn(mockDashboard, 'othersAwaitExecution').and.callThrough();
+    spyOn(mockDashboard, 'updateComponent').and.callThrough();
+
+    spyOn(comp1priority5, 'preExecution').and.callThrough();
+    spyOn(comp1priority5, 'update').and.callThrough();
+    spyOn(comp1priority5, 'postExecution').and.callThrough();
+
+    // call Dashboards.updateAll
+    mockDashboard.updateAll( [ comp1priority5 ] );
+
+    var validate = function(){
+
+      // Dashboards.updateAll call component.on when the updating begins (@see Dashboards.main:updateAll)
+      expect( mockDashboard.updateComponent.calls.count() ).toEqual( 1 ); 
+
+      expect( comp1priority5.preExecutionFlag ).toEqual( 1 );
+      expect( comp1priority5.updateFlag ).toEqual( 1 );
+      expect( comp1priority5.postExecutionFlag ).toEqual( 1 );
+
+      done();
+    }
+
+    setTimeout( validate, 100 ); 
+  });
+
+  it("Should go through Dashboards.updateAll handling comp2priority5 and *not* comp1priority5 (because it's already in an updated status), with an updateTier array already holding comp1priority5 and a new update call made to comp2priority5", function(done){
+
+    var mockDashboard = _.extend({},Dashboards);
+
+    mockDashboard.updateQueue = undefined;
+    comp1priority5.reset();
+    comp2priority5.reset();
+    comp3priority10.reset();
+
+    mockDashboard.components = [ comp1priority5, comp2priority5, comp3priority10 ];
+
+    var mockUpdateTiers = {  5:  [ comp1priority5 ] };
+
+    var mockUpdateCurrent = { components: [ comp1priority5 ], priority: comp1priority5.priority };
+
+    mockDashboard.updating = { tiers: mockUpdateTiers, current: mockUpdateCurrent };
+        
+    spyOn(mockDashboard, 'othersAwaitExecution').and.callThrough();
+    spyOn(mockDashboard, 'updateComponent').and.callThrough();    
+    
+    spyOn(comp1priority5, 'preExecution').and.callThrough();
+    spyOn(comp1priority5, 'update').and.callThrough();
+    spyOn(comp1priority5, 'postExecution').and.callThrough();
+
+    spyOn(comp2priority5, 'preExecution').and.callThrough();
+    spyOn(comp2priority5, 'update').and.callThrough();
+    spyOn(comp2priority5, 'postExecution').and.callThrough();
+
+    // call Dashboards.updateAll
+    mockDashboard.updateAll( [ comp2priority5 ] );
+
+    // so: comp1priority5 is currently marked as executing, and comp2priority5 has just been triggered for update
+    expect( mockDashboard.othersAwaitExecution ).toBeTruthy();
+
+    var validateUpdateCycle = function(){
+
+      // comp1priority5 had already been updated and consequently marked as dashboards.updating.current, so no updating should be done for it
+      expect( comp1priority5.preExecutionFlag ).toEqual( 0 );
+      expect( comp1priority5.updateFlag ).toEqual( 0 );
+      expect( comp1priority5.postExecutionFlag ).toEqual( 0 );
+
+      // Dashboards.updateAll call component.on when the updating begins (@see Dashboards.main:updateAll)
+      expect( mockDashboard.updateComponent.calls.count() ).toEqual( 1 ); 
+
+      expect( comp2priority5.preExecutionFlag ).toEqual( 1 );
+      expect( comp2priority5.updateFlag ).toEqual( 1 );
+      expect( comp2priority5.postExecutionFlag ).toEqual( 1 );
+
+      done();
+    }
+
+    setTimeout( validateUpdateCycle, 100 ); 
+
+  });
+
+  it("Should go through Dashboards.updateAll handling comp1priority5 and *only after comp1priority5's end* it should handle comp3priority10, when a call is made to comp3priority10 (due to its lower priority)", function(done){
+
+    var mockDashboard = _.extend({},Dashboards);
+
+    mockDashboard.updateQueue = undefined;
+    comp1priority5.reset();
+    comp2priority5.reset();
+    comp3priority10.reset();
+
+    mockDashboard.components = [ comp1priority5, comp2priority5, comp3priority10 ];
+
+    var mockUpdateTiers = {  5:  [ comp1priority5 ] };
+
+    var mockUpdateCurrent = null;
+
+    mockDashboard.updating = { tiers: mockUpdateTiers, current: mockUpdateCurrent };
+        
+    spyOn(mockDashboard, 'othersAwaitExecution').and.callThrough();
+    spyOn(mockDashboard, 'updateComponent').and.callThrough();    
+    
+    spyOn(comp1priority5, 'preExecution').and.callThrough();
+    spyOn(comp1priority5, 'update').and.callThrough();
+    spyOn(comp1priority5, 'postExecution').and.callThrough();
+
+    spyOn(comp3priority10, 'preExecution').and.callThrough();
+    spyOn(comp3priority10, 'update').and.callThrough();
+    spyOn(comp3priority10, 'postExecution').and.callThrough();
+
+    // call Dashboards.updateAll
+    mockDashboard.updateAll( [ comp3priority10 ] ); 
+ 
+    // although comp3priority10 has been triggered for updating, it *should* be discarded from this execution cycle due to lower priority rate
+    // ( read: 1rst is comp1priority5, then is comp3priority10 )
+    expect( mockDashboard.othersAwaitExecution ).toBeTruthy();
+
+    var validateUpdateCycle = function(){
+
+      // comp1priority5 had already been updated and consequently marked as dashboards.updating.current, so no updating should be done for it
+      expect( comp1priority5.preExecutionFlag ).toEqual( 1 );
+      expect( comp1priority5.updateFlag ).toEqual( 1 );
+      expect( comp1priority5.postExecutionFlag ).toEqual( 1 );
+
+      expect( comp3priority10.preExecutionFlag ).toEqual( 0 );
+      expect( comp3priority10.updateFlag ).toEqual( 0 );
+      expect( comp3priority10.postExecutionFlag ).toEqual( 0 );
+
+      // Dashboards.updateAll calls updateComponent (@see Dashboards.main:updateAll)
+      expect( mockDashboard.updateComponent.calls.count() ).toEqual( 1 ); 
+
+      // we need to do this by hand because we cannot mock this (Dashboards.Main:1107)
+      /*
+       * var current = this.updating.current;
+       * current.components = _.without(current.components, component);
+       * var tiers = this.updating.tiers;
+       * tiers[current.priority] = _.without(tiers[current.priority], component);
+       * this.updateAll();
+       */
+
+      var current = mockDashboard.updating.current;
+      current.components = _.without(current.components, comp1priority5);
+      var tiers = mockDashboard.updating.tiers;
+      tiers[current.priority] = _.without(tiers[current.priority], comp1priority5);
+      mockDashboard.updateAll();
+
+    }
+
+    var validateNextUpdateCycle = function(){
+
+      // Dashboards.updateAll has updated comp3priority10
+      expect( mockDashboard.updateComponent.calls.count() ).toEqual( 2 ); 
+
+      expect( comp3priority10.preExecutionFlag ).toEqual( 1 );
+      expect( comp3priority10.updateFlag ).toEqual( 1 );
+      expect( comp3priority10.postExecutionFlag ).toEqual( 1 );
+
+      done();
+    }
+
+    setTimeout( validateUpdateCycle, 100 );
+    setTimeout( validateNextUpdateCycle, 200 ); 
+
+  });
+
+
+  it("Should go through Dashboards.updateAll handling comp2priority5 and *not* comp1priority5 (as it is already under updating) and *only after comp2priority5's end* it should handle comp3priority10  (due to its lower priority), when a call is made to comp2priority5", function(done){
+
+    var mockDashboard = _.extend({},Dashboards);
+
+    mockDashboard.updateQueue = undefined;
+    comp1priority5.reset();
+    comp2priority5.reset();
+    comp3priority10.reset();
+
+    mockDashboard.components = [ comp1priority5, comp2priority5, comp3priority10 ];
+
+    var mockUpdateTiers = {  5:  [ comp1priority5 ], 10: [ comp3priority10 ] };
+
+    var mockUpdateCurrent = { components: [ comp1priority5 ], priority: comp1priority5.priority };
+
+    mockDashboard.updating = { tiers: mockUpdateTiers, current: mockUpdateCurrent };
+        
+    spyOn(mockDashboard, 'othersAwaitExecution').and.callThrough();
+    spyOn(mockDashboard, 'updateComponent').and.callThrough();    
+    
+    spyOn(comp1priority5, 'preExecution').and.callThrough();
+    spyOn(comp1priority5, 'update').and.callThrough();
+    spyOn(comp1priority5, 'postExecution').and.callThrough();
+
+    spyOn(comp2priority5, 'preExecution').and.callThrough();
+    spyOn(comp2priority5, 'update').and.callThrough();
+    spyOn(comp2priority5, 'postExecution').and.callThrough();
+
+    spyOn(comp3priority10, 'preExecution').and.callThrough();
+    spyOn(comp3priority10, 'update').and.callThrough();
+    spyOn(comp3priority10, 'postExecution').and.callThrough();
+
+    // call Dashboards.updateAll
+    mockDashboard.updateAll( [ comp2priority5 ] ); 
+ 
+    // although comp3priority10 has been triggered for updating, it *should* be discarded from this execution cycle due to lower priority rate
+    // ( read: 1rst is comp2priority5, then is comp3priority10 )
+    expect( mockDashboard.othersAwaitExecution ).toBeTruthy();
+
+    var validateUpdateCycle = function(){
+
+      // comp1priority5 had already been updated and consequently marked as dashboards.updating.current, so no updating should be done for it
+      expect( comp1priority5.preExecutionFlag ).toEqual( 0 );
+      expect( comp1priority5.updateFlag ).toEqual( 0 );
+      expect( comp1priority5.postExecutionFlag ).toEqual( 0 );
+
+      // comp2priority5 has been marked for updating, and given that is has a hiher priority than comp3priority10, it should be triggered now
+      expect( comp2priority5.preExecutionFlag ).toEqual( 1 );
+      expect( comp2priority5.updateFlag ).toEqual( 1 );
+      expect( comp2priority5.postExecutionFlag ).toEqual( 1 );
+
+      // although comp3priority10 has been triggered for updating, it *should* be discarded from this execution cycle due to lower priority rate
+      // ( read: 1rst is comp2priority5, then is comp3priority10 )
+      expect( comp3priority10.preExecutionFlag ).toEqual( 0 );
+      expect( comp3priority10.updateFlag ).toEqual( 0 );
+      expect( comp3priority10.postExecutionFlag ).toEqual( 0 );
+
+      // Dashboards.updateAll calls updateComponent (@see Dashboards.main:updateAll)
+      expect( mockDashboard.updateComponent.calls.count() ).toEqual( 1 ); 
+
+      // we need to do this by hand because we cannot mock this (Dashboards.Main:1107)
+      /*
+       * var current = this.updating.current;
+       * current.components = _.without(current.components, component);
+       * var tiers = this.updating.tiers;
+       * tiers[current.priority] = _.without(tiers[current.priority], component);
+       * this.updateAll();
+       */
+
+      var current = mockDashboard.updating.current;
+      current.components = _.without(current.components, comp2priority5);
+      var tiers = mockDashboard.updating.tiers;
+      tiers[current.priority] = _.without(tiers[current.priority], comp2priority5);
+      mockDashboard.updateAll();
+
+    }
+
+    var validateNextUpdateCycle = function(){
+
+      // Dashboards.updateAll has updated comp3priority10
+      expect( mockDashboard.updateComponent.calls.count() ).toEqual( 2 ); 
+
+      expect( comp3priority10.preExecutionFlag ).toEqual( 1 );
+      expect( comp3priority10.updateFlag ).toEqual( 1 );
+      expect( comp3priority10.postExecutionFlag ).toEqual( 1 );
+
+      done();
+    }
+
+    setTimeout( validateUpdateCycle, 100 );
+    setTimeout( validateNextUpdateCycle, 200 ); 
+
+  });
+
 });


### PR DESCRIPTION
```
- added additional unit tests where components of a lower priority will wait for next update cycle (because they have lower priority than the ones being updated)
- re-did existing unit tests to a) test more scenarios and b) clean the failed tests in CI
- note:  timeouts are still being set in this test, as their removal is an effort left for require-js' refactor
- the additional unit tests for components of a lower priority actually identified (thus the fix) a bug in the original commit
```
