### PR TITLE
[CDF-423] Regression: Pentaho EE 5.0.7 with latest CTools v14.10.15 is b...

### DIFF
--- a/cdf-pentaho5/cdf/js/cdf-require-js-cfg.js
+++ b/cdf-pentaho5/cdf/js/cdf-require-js-cfg.js
@@ -66,7 +66,7 @@ requireCfg['shim']['cdf/Dashboards.Main'] = [
     'cdf/mustache', 
     'cdf/lib/shims',
     'cdf/jquery.blockUI',
-    'cdf/uriQueryParser/jquery-queryParser.js',    
+    '../pentaho-cdf/js/uriQueryParser/jquery-queryParser.js',    
     'cdf/Dashboards.Startup',
     'cdf/cdf-base'
 ];
@@ -127,7 +127,7 @@ requireCfg['shim']['cdf/jquery.jdMenu']          = ['cdf/jquery'];
 requireCfg['shim']['cdf/jquery.positionBy']      = ['cdf/jquery'];
 requireCfg['shim']['cdf/jquery.sparkline']       = ['cdf/jquery'];
 
-requireCfg['shim']['cdf/uriQueryParser/jquery-queryParser.js'] = ['cdf/jquery'];
+requireCfg['shim']['../pentaho-cdf/js/uriQueryParser/jquery-queryParser.js'] = ['cdf/jquery'];
 
 requireCfg['shim']['cdf/simile/ajax/scripts/json'] = ['cdf/simile/ajax/simile-ajax-api'];
 


### PR DESCRIPTION
...reaking PIR

```
- PIR @ Biserver EE < 5.1.0 (a.k.a. pre-require-js) is incapable of fetching non-bundled dependencies
- there is only one such dependency, which is the (recently included) jquery-queryParser.js
```
