### PR TITLE
[CDF-271] - Upgrade jquery version on CDF

### DIFF
--- a/cdf-core/cdf/js/Dashboards.Startup.js
+++ b/cdf-core/cdf/js/Dashboards.Startup.js
@@ -1,15 +1,15 @@
 /*!
-* Copyright 2002 - 2013 Webdetails, a Pentaho company.  All rights reserved.
-* 
-* This software was developed by Webdetails and is provided under the terms
-* of the Mozilla Public License, Version 2.0, or any later version. You may not use
-* this file except in compliance with the license. If you need a copy of the license,
-* please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
-*
-* Software distributed under the Mozilla Public License is distributed on an "AS IS"
-* basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
-* the license for the specific language governing your rights and limitations.
-*/
+ * Copyright 2002 - 2014 Webdetails, a Pentaho company.  All rights reserved.
+ * 
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
 
 $.ajaxSetup({
   type: "POST",
@@ -61,9 +61,10 @@ if($.blockUI){
 
 
 
-if (typeof $.SetImpromptuDefaults == 'function') {
-  $.SetImpromptuDefaults({
-    prefix: 'colsJqi',
+//Set impromptu defaults
+if($.prompt && typeof $.prompt.setDefaults == 'function') {
+  $.prompt.setDefaults({
+    prefix: 'jqi',
     show: 'slideDown'
   });
 }


### PR DESCRIPTION
```
- Replaced deprecated function $.SetImpromptuDefaults with $.prompt.setDefaults (version 5.2.4)
- Set prefix to 'jqi' (impromptu's default CSS prefix) because the examples using colsJqi prefix were removed from jquery-impromptu.css (version 5.2.4)
```
