### PR TITLE
cherry-pick and applied to require-js '[CDF-271] - Upgrade jquery version on CDF'

### DIFF
--- a/cdf-core/cdf/js-modules/dashboard/Dashboard.js
+++ b/cdf-core/cdf/js-modules/dashboard/Dashboard.js
@@ -11,9 +11,17 @@
  * the license for the specific language governing your rights and limitations.
  */
 
-define (['../lib/Base', '../lib/jquery', '../Logger', './RefreshEngine', '../lib/underscore', '../lib/backbone',
-      '../lib/shims', 'css!../lib/cdf.css', '../lib/modernizr'],
-    function(Base, $, Logger, RefreshEngine, _, Backbone) {
+define([
+  '../lib/Base',
+  '../Logger',
+  './RefreshEngine',
+  '../lib/underscore',
+  '../lib/backbone',
+  '../lib/jquery',
+  '../lib/jquery.impromptu',
+  '../lib/shims',
+  'css!../lib/cdf.css'],
+  function(Base, Logger, RefreshEngine, _, Backbone, $) {
 
   /**
    * A module representing a Dashboard.
@@ -100,14 +108,14 @@ define (['../lib/Base', '../lib/jquery', '../Logger', './RefreshEngine', '../lib
             }
           });
   
-          //SetImpromptuDefaults
-          if(typeof $.SetImpromptuDefaults == 'function') {
-            $.SetImpromptuDefaults({
-              prefix: 'colsJqi',
+          //Set impromptu defaults
+          if($.prompt && typeof $.prompt.setDefaults == 'function') {
+            $.prompt.setDefaults({
+              prefix: 'jqi',
               show: 'slideDown'
             });
           } else {
-            Logger.log("$.SetImpromptuDefaults plugin not loaded!!!!!!!!");
+            Logger.log("$.prompt plugin not loaded!!!!!!!!");
           }
   
           //blockUI

--- a/cdf-core/cdf/js/Dashboards.Startup.js
+++ b/cdf-core/cdf/js/Dashboards.Startup.js
@@ -61,9 +61,10 @@ if($.blockUI){
 
 
 
-if (typeof $.SetImpromptuDefaults == 'function') {
-  $.SetImpromptuDefaults({
-    prefix: 'colsJqi',
+//Set impromptu defaults
+if($.prompt && typeof $.prompt.setDefaults == 'function') {
+  $.prompt.setDefaults({
+    prefix: 'jqi',
     show: 'slideDown'
   });
 }


### PR DESCRIPTION
```
- Replaced deprecated function $.SetImpromptuDefaults with $.prompt.setDefaults (version 5.2.4)
- Set prefix to 'jqi' (impromptu's default CSS prefix) because the examples using colsJqi prefix were removed from jquery-impromptu.css (version 5.2.4)
```
