### PR TITLE
[CDF-468] [BA-Server EE 4.8.3] Analyzer plugin breaks using CDF core-ref...

### DIFF
--- a/cdf-pentaho/build.properties
+++ b/cdf-pentaho/build.properties
@@ -15,10 +15,10 @@ dependency.jxl.revision=2.6.12
 dependency.junit.revision=4.10
 
 #modifications needed for core-refator components/ccc.js
-cdf.ccc.require.header=
-cdf.ccc.published.globally=
-cdf.ccc.var.declaration=var
-cdf.ccc.require.footer=
+cdf.ccc.require.header=require(["cdf/lib/CCC/protovis", "cdf/lib/CCC/cdo", "cdf/lib/CCC/pvc-d1.0", "cdf/lib/CCC/def", "cdf/components/core"], function(_pv, _cdo, _pvc, _def) {
+cdf.ccc.published.globally=pvc = _pvc; pv  = _pv; def = _def; cdo = _cdo;
+cdf.ccc.var.declaration=
+cdf.ccc.require.footer=});
 
 # project maturity
 marketplace.metadata.development_stage.lane=Customer

--- a/cdf-pentaho/build.xml
+++ b/cdf-pentaho/build.xml
@@ -195,7 +195,7 @@
 	    <antcall target="write-properties" />
 	    <!-- copy ccc build -->
         <copy todir="${stage.dir}/${plugin.name}/js/lib/CCC" >
-            <fileset dir="${js.expanded.lib.dir}/ccc/ccc"/>
+            <fileset dir="${js.expanded.lib.dir}/ccc/pen"/>
         </copy>
 
         <!-- rename ccc files -->
@@ -467,6 +467,22 @@ excludes="**/Thumbs.db"
                 </propertyfile>
             </sequential>
         </for>
+        <!-- cdf-pentaho/cdf-pentaho5 *optional* property extra-core-scripts-1 -->
+        <if>
+  			<isset property="extra-core-scripts-1" />
+  			<then>
+    			<for list='${extra-core-scripts-1}' param='filename'>
+            		<sequential>
+                		<propertyfile file="${stage-resources.path}">
+                    		<entry key="script" operation="+" value="@{filename},"/>
+                		</propertyfile>
+            		</sequential>
+        		</for>
+  			</then>
+  			<else>
+  				<!-- skip, this is an optional property -->
+  			</else>
+		</if>
         <!-- cdf-core property core-scripts-2 -->
         <for list='${core-scripts-2}' param='filename'>
             <sequential>
@@ -475,6 +491,22 @@ excludes="**/Thumbs.db"
                 </propertyfile>
             </sequential>
         </for>
+        <!-- cdf-pentaho/cdf-pentaho5 *optional* property extra-core-scripts-2 -->
+        <if>
+  			<isset property='extra-core-scripts-2' />
+  			<then>
+    			<for list='${extra-core-scripts-2}' param='filename'>
+            		<sequential>
+                		<propertyfile file="${stage-resources.path}">
+                    		<entry key="script" operation="+" value="@{filename},"/>
+                		</propertyfile>
+            		</sequential>
+        		</for>
+  			</then>
+  			<else>
+  				<!-- skip, this is an optional property -->
+  			</else>
+		</if>
         <!-- cdf-pentaho property pentaho-scripts-1 -->
         <for list='${pentaho-scripts-1}' param='filename'>
             <sequential>
@@ -491,6 +523,22 @@ excludes="**/Thumbs.db"
                 </propertyfile>
             </sequential>
         </for>
+        <!-- cdf-pentaho/cdf-pentaho5 *optional* property extra-core-scripts-3 -->
+        <if>
+  			<isset property='extra-core-scripts-3' />
+  			<then>
+    			<for list='${extra-core-scripts-3}' param='filename'>
+            		<sequential>
+                		<propertyfile file="${stage-resources.path}">
+                    		<entry key="script" operation="+" value="@{filename},"/>
+                		</propertyfile>
+            		</sequential>
+        		</for>
+  			</then>
+  			<else>
+  				<!-- skip, this is an optional property -->
+  			</else>
+		</if>
         <!-- cdf-pentaho-base property pentaho-base-scripts -->
         <for list='${pentaho-base-scripts}' param='filename'>
             <sequential>

--- a/cdf-pentaho/resource/resources.properties
+++ b/cdf-pentaho/resource/resources.properties
@@ -3,6 +3,10 @@
 # 
 # script/link will be included first; assume nothing for others
 
+# applying this after cdf-core's core-scripts-1
+extra-core-scripts-1=\
+js/lib/pen-shim.js
+
 pentaho-scripts-1=\
 js/cdf-base.js,\
 js/cccHelper.js,\


### PR DESCRIPTION
...actored

	- cdf-pentaho ( 4.8.x ) was including js-lib/ccc/ccc instead of proper js-lib/ccc/pen
	- including js-lib/ccc/pen also requires js/lib/pen-shim.js dependency inclusion
	- pen-shim.js ( in minified cdf-blueprint ) must be declared *before* cdf-core core-scripts-2's def.js, otherwise it will fail with 'pen is not defined'
	- cdf-pentaho ( 4.8.x ) build.xml now includes 'extra-core-scripts 1/2/3', to allow cdf-pentaho to add its own dependencies at cdf-core's core-scripts level
	- updated ccc.js to properly work with new js-lib/ccc/pen ( which in all reality ended up editing build.properties and make it similar to cdf-pentaho5 one )
	- tested core-components , samples and analyzer