### PR TITLE
[CDF-355] Enable configLanguage to also configure moment locale

### DIFF
--- a/cdf-core/cdf/js/Dashboards.Utils.js
+++ b/cdf-core/cdf/js/Dashboards.Utils.js
@@ -82,8 +82,23 @@ Dashboards.getLocationSearchString = function() {
     return formProvider.number().mask(mask)(value);
   };
 
+  /**
+   * Config a new or existing language by specifying the language code
+   * and a configuration object with the keywords:
+   *  - 'number'     to configure number's format language
+   *  - 'dateLocale' to configure date's   format language
+   *
+   * @param langCode
+   * @param config
+   */
   D.configLanguage = function(langCode, config) {
+    var dateConfig = config.dateLocale || {};
+    var mLocale = moment.locale();
+    delete config.dateLocale;
+
     cdo.format.language(langCode, config);
+    moment.locale(langCode, dateConfig);
+    moment.locale(mLocale);
   };
 
   /**


### PR DESCRIPTION
We are storing the current locale and setting it after the configuration is done, because moment starts using the new locale after that and we just want to configure it for later use.

@pamval please review