### PR TITLE
[CDF-524] Change sample on prptComponent to point to other report

### DIFF
--- a/cdf-pentaho/solution/plugin-samples/pentaho-cdf/30-documentation/30-component_reference/10-core/63-PentahoReportingComponent/template.html
+++ b/cdf-pentaho/solution/plugin-samples/pentaho-cdf/30-documentation/30-component_reference/10-core/63-PentahoReportingComponent/template.html
@@ -81,7 +81,7 @@
 			</ul>
 			<div id="sample">
 				<div id="selectorObject"></div>
-				<div id="sampleObject"></div>
+				<div id="sampleObject" style="height:600px;"></div>
 				<br/>
 			</div>
 
@@ -89,10 +89,9 @@
 			<div id="code">
 				<textarea cols="80" rows="20" id="samplecode">
 
-output_type = "";
+var output_type = "";
 
-outputSelector = 
-{
+var outputSelector = {
 	name: "outputSelector",
 	type: "select",
 	parameters:[],
@@ -103,8 +102,7 @@ outputSelector =
 	executeAtStart: true
 };
 
-orderStatusReport = 
-{
+var orderStatusReport = {
   name: "orderStatus",
   type: "prpt",
   solution: "steel-wheels",
@@ -119,11 +117,8 @@ orderStatusReport =
   executeAtStart: true
 }
 				
-
 Dashboards.init([outputSelector,orderStatusReport]);
 Dashboards.finishedInit = false;
-
-
 				</textarea>
 				<br />
 				<button onclick="evaluateCode(true)">Try me</button>

--- a/cdf-pentaho5/solution/plugin-samples/pentaho-cdf/30-documentation/30-component_reference/10-core/63-PentahoReportingComponent/template.html
+++ b/cdf-pentaho5/solution/plugin-samples/pentaho-cdf/30-documentation/30-component_reference/10-core/63-PentahoReportingComponent/template.html
@@ -80,7 +80,7 @@
 			</ul>
 			<div id="sample">
 				<div id="selectorObject"></div>
-				<div id="sampleObject" style="height:530px"></div>
+				<div id="sampleObject" style="height:600px"></div>
 				<br/>
 			</div>
 
@@ -88,10 +88,9 @@
 			<div id="code">
 				<textarea cols="80" rows="20" id="samplecode">
 
-output_type = "";
+var output_type = "";
 
-outputSelector = 
-{
+var outputSelector = {
 	name: "outputSelector",
 	type: "select",
 	parameters:[],
@@ -102,11 +101,10 @@ outputSelector =
 	executeAtStart: true
 };
 
-orderStatusReport = 
-{
+var orderStatusReport = {
   name: "orderStatus",
   type: "prptComponent",
-  path: "/public/Steel Wheels/Widget Library/Report Snippets/Product Sales.prpt",
+  path: "/public/Steel Wheels/Widget Library/Report Snippets/InventorybyLine.prpt",
   listeners:["output_type"],
   parameters: [["output-type","output_type"]],
   htmlObject: "sampleObject",
@@ -115,12 +113,9 @@ orderStatusReport =
   iframe: true,
   executeAtStart: true
 }
-				
 
 Dashboards.init([outputSelector,orderStatusReport]);
 Dashboards.finishedInit = false;
-
-
 				</textarea>
 				<br />
 				<button onclick="evaluateCode(true)">Try me</button>

--- a/cdf-pentaho5/solution/plugin-samples/pentaho-cdf/pentaho-cdf-require/30-documentation/30-component_reference/10-core/63-PentahoReportingComponent/template.html
+++ b/cdf-pentaho5/solution/plugin-samples/pentaho-cdf/pentaho-cdf-require/30-documentation/30-component_reference/10-core/63-PentahoReportingComponent/template.html
@@ -7,7 +7,7 @@
 
     <h3>Description</h3>
     <p>
-    This is a component that can execute the new Pentaho Reporting unified file format. The result is displayed in the PUC Report Viewer, 
+    This is a component that can execute the new Pentaho Reporting unified file format. The result is displayed in the PUC Report Viewer,
     including the new parameter and pagination features. For better use in CDF, parameter and pagination in the report viewer can be turned on or off.
     </p>
 
@@ -22,7 +22,7 @@
 
       <dt>listeners</dt>
       <dd><i>Array - </i> Parameters who this component will react to</dd>
-      
+
       <dt>parameters</dt>
       <dd><i>Array of Arrays - </i> Parameters to pass to the report</dd>
 
@@ -49,7 +49,7 @@
 
       <dt>tooltip</dt>
       <dd>Tooltip to be displayed when mouse hovers</dd>
-      
+
       <dt>solution</dt>
       <dd>Solution where the Pentaho Reporting file is</dd>
 
@@ -58,14 +58,14 @@
 
       <dt>action</dt>
       <dd>Pentaho Reporting file name (unified file format *.prpt)</dd>
-      
-      <dt>paginate</dt> 
+
+      <dt>paginate</dt>
       <dd>Pentaho Report Viewer paginate option. Default: true</dd>
-      
-      <dt>showParameters</dt> 
+
+      <dt>showParameters</dt>
       <dd>Pentaho Report Viewer parameter option. Default: false</dd>
 
-      <dt>iframe</dt> 
+      <dt>iframe</dt>
       <dd> Wheather to render the report inside an iframe or inline. Default: true (iframe)</dd>
 
     </dl>
@@ -79,7 +79,7 @@
       </ul>
       <div id="sample">
         <div id="selectorObject"></div>
-        <div id="sampleObject"></div>
+        <div id="sampleObject" style="height:600px; width:920px ;"></div>
         <br/>
       </div>
 
@@ -105,7 +105,7 @@ require(['cdf/Dashboard.Blueprint', 'cdf/components/SelectComponent', 'cdf/compo
     dashboard.addComponent(new PrptComponent({
       name: "orderStatusReport",
       type: "prptComponent",
-      path: "/public/Steel Wheels/Widget Library/Report Snippets/Product Sales.prpt",
+      path: "/public/Steel Wheels/Widget Library/Report Snippets/InventorybyLine.prpt",
       listeners:["output_type"],
       parameters: [["output-type","output_type"]],
       htmlObject: "sampleObject",


### PR DESCRIPTION
Changed the report in the 5.x sample to:
 - /public/Steel Wheels/Widget Library/Report Snippets/InventorybyLine.prpt

On the 4.x sample the report already could be exported to CSV and Text

@pamval please review