### PR TITLE
[CDF-512] missing lib in karma legacy config file

### DIFF
--- a/cdf-core/config/karma.ci.conf.legacy.js
+++ b/cdf-core/config/karma.ci.conf.legacy.js
@@ -37,6 +37,7 @@ module.exports = function(config) {
       'cdf/js-lib/underscore/underscore.js',
       'cdf/js-lib/backbone/backbone.js',
       'cdf/js-lib/mustache/mustache.js',
+      'cdf/js-lib/moment/moment.js',
       'cdf/js-lib/base/Base.js',
       '../cdf-pentaho5/cdf/js/cdf-base.js',
       'cdf/js/Dashboards.Main.js',


### PR DESCRIPTION
@pamval I ran the karma tests on my machine and they all had passed, but I was alerted now by @afrjorge that sometimes some legacy tests are not executed. That was why this problem was not caught before the previous merge. please review