### PR TITLE
[CLEANUP]

### DIFF
--- a/cdf-pentaho/config/karma.ci.conf.js
+++ b/cdf-pentaho/config/karma.ci.conf.js
@@ -117,7 +117,11 @@ module.exports = function(config) {
     // If browser does not capture in given timeout [ms], kill it
     captureTimeout: 60000,
 
-    //browserNoActivityTimeout: 20000,
+    // to avoid DISCONNECTED messages
+    // see https://github.com/karma-runner/karma/issues/598
+    browserDisconnectTimeout : 10000, // default 2000
+    browserDisconnectTolerance : 1, // default 0
+    browserNoActivityTimeout : 60000, //default 10000
 
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit

--- a/cdf-pentaho/config/karma.conf.js
+++ b/cdf-pentaho/config/karma.conf.js
@@ -117,7 +117,7 @@ module.exports = function(config) {
     // If browser does not capture in given timeout [ms], kill it
     captureTimeout: 60000,
 
-    //browserNoActivityTimeout: 20000,
+    browserNoActivityTimeout: 600000,
 
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit

--- a/cdf-pentaho5/config/karma.ci.conf.js
+++ b/cdf-pentaho5/config/karma.ci.conf.js
@@ -91,7 +91,11 @@ module.exports = function(config) {
     // If browser does not capture in given timeout [ms], kill it
     captureTimeout: 60000,
 
-    //browserNoActivityTimeout: 1200000,
+    // to avoid DISCONNECTED messages
+    // see https://github.com/karma-runner/karma/issues/598
+    browserDisconnectTimeout : 10000, // default 2000
+    browserDisconnectTolerance : 1, // default 0
+    browserNoActivityTimeout : 60000, //default 10000
 
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit
@@ -103,9 +107,7 @@ module.exports = function(config) {
       'karma-junit-reporter',
       'karma-html-reporter',
       'karma-coverage',
-      'karma-phantomjs-launcher',
-      'karma-chrome-launcher',
-      'karma-firefox-launcher'
+      'karma-phantomjs-launcher'
     ]
   });
 };

--- a/cdf-pentaho5/config/karma.ci.conf.legacy.js
+++ b/cdf-pentaho5/config/karma.ci.conf.legacy.js
@@ -115,7 +115,11 @@ module.exports = function(config) {
     // If browser does not capture in given timeout [ms], kill it
     captureTimeout: 60000,
 
-    //browserNoActivityTimeout: 120000,
+    // to avoid DISCONNECTED messages
+    // see https://github.com/karma-runner/karma/issues/598
+    browserDisconnectTimeout : 10000, // default 2000
+    browserDisconnectTolerance : 1, // default 0
+    browserNoActivityTimeout : 60000, //default 10000
 
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit
@@ -127,9 +131,7 @@ module.exports = function(config) {
       'karma-junit-reporter',
       'karma-html-reporter',
       'karma-coverage',
-      'karma-phantomjs-launcher',
-      'karma-chrome-launcher',
-      'karma-firefox-launcher'
+      'karma-phantomjs-launcher'
     ]
   });
 };

--- a/cdf-pentaho5/config/karma.conf.js
+++ b/cdf-pentaho5/config/karma.conf.js
@@ -91,7 +91,7 @@ module.exports = function(config) {
     // If browser does not capture in given timeout [ms], kill it
     captureTimeout: 60000,
 
-    //browserNoActivityTimeout: 20000,
+    browserNoActivityTimeout: 600000,
 
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit

--- a/cdf-pentaho5/config/karma.conf.legacy.js
+++ b/cdf-pentaho5/config/karma.conf.legacy.js
@@ -115,7 +115,7 @@ module.exports = function(config) {
     // If browser does not capture in given timeout [ms], kill it
     captureTimeout: 60000,
 
-    //browserNoActivityTimeout: 20000,
+    browserNoActivityTimeout: 600000,
 
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit


### PR DESCRIPTION
	- Avoid DISCONNECTED messages while running tests using PhantomJS, for 4.x and 5 tests also