### PR TITLE
[CDF-546] adding missing css file for require Date Input Component

### DIFF
--- a/cdf-core/cdf/js-modules/components/DateInputComponent.css
+++ b/cdf-core/cdf/js-modules/components/DateInputComponent.css
@@ -1,0 +1,16 @@
+/*!
+ * Copyright 2002 - 2015 Webdetails, a Pentaho company. All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+
+.date-input-container .date-input {
+  width: 80px
+}


### PR DESCRIPTION
This file was not included in last pull request and has the css rules for the require Date Input Component
@pamval please review