### PR TITLE
[CLEANUP][CDF-571]

### DIFF
--- a/cdf-core/test-js/dashboard/Dashboard.views-spec.js
+++ b/cdf-core/test-js/dashboard/Dashboard.views-spec.js
@@ -17,7 +17,8 @@ define(["cdf/Dashboard.Clean", 'cdf/lib/jquery'], function(Dashboard, $) {
    * ## The CDF framework Dashboard Views
    */
   describe("The CDF framework Dashboard Views #", function() {
-    var dashboard;
+    var dashboard,
+        serverResponse = {test: 1};
     
     /**
      * ## Global settings for all suites.
@@ -33,6 +34,10 @@ define(["cdf/Dashboard.Clean", 'cdf/lib/jquery'], function(Dashboard, $) {
      * ## Dashboard Views # correctly calls the initViews
      */
     it("correctly calls the initViews", function(done) {
+      spyOn($, "ajax").and.callFake(function(params) {
+        params.success(serverResponse);
+      });
+
       // listen to cdf:postInit event
       dashboard.once("cdf:postInit", function() {
         expect(dashboard._initViews).toBeDefined();
@@ -48,16 +53,12 @@ define(["cdf/Dashboard.Clean", 'cdf/lib/jquery'], function(Dashboard, $) {
      * ## The CDF framework Dashboard Views # sets the view object according to server response
      */
     it("sets the view object according to server response", function(done) {
-      var serverResponse = {test: 1};
-
-      spyOn($, "ajax").and.callFake(function(params) {
-        params.success(serverResponse);
-      });
-
       dashboard.init();
 
-      // listen to cdf:postInit event
-      dashboard.once("cdf:postInit", function() {
+      spyOn(dashboard, "_initViews").and.callThrough();
+      spyOn($, "ajax").and.callFake(function(params) {
+        params.success(serverResponse);
+        expect(dashboard._initViews.calls.count()).toEqual(1);
         expect(dashboard.view).toEqual(serverResponse);
         done();
       });

--- a/cdf-pentaho5/config/cdf.build.compile.js
+++ b/cdf-pentaho5/config/cdf.build.compile.js
@@ -181,7 +181,8 @@
         "cdf/queries/BaseQuery",
         "cdf/queries/CdaQuery",
         "cdf/queries/CpkQuery",
-        "cdf/queries/LegacyQuery"
+        "cdf/queries/LegacyQuery",
+        "cdf/queries/XmlaQuery"
       ],
 
       //Exclude the modules listed bellow and their dependencies from the built file. If you want
@@ -224,7 +225,8 @@
         "cdf/dashboard/Dashboard.notifications.ext",
         "cdf/dashboard/Dashboard.storage.ext",
         "cdf/dashboard/Dashboard.views.ext",
-        "cdf/queries/CdaQuery.ext"
+        "cdf/queries/CdaQuery.ext",
+        "cdf/queries/XmlaQuery.ext"
       ]
     },
     {
@@ -259,7 +261,8 @@
         "cdf/queries/BaseQuery",
         "cdf/queries/CdaQuery",
         "cdf/queries/CpkQuery",
-        "cdf/queries/LegacyQuery"
+        "cdf/queries/LegacyQuery",
+        "cdf/queries/XmlaQuery"
       ],
 
       //Exclude the modules listed bellow and their dependencies from the built file. If you want
@@ -308,7 +311,8 @@
         "cdf/dashboard/Dashboard.notifications.ext",
         "cdf/dashboard/Dashboard.storage.ext",
         "cdf/dashboard/Dashboard.views.ext",
-        "cdf/queries/CdaQuery.ext"
+        "cdf/queries/CdaQuery.ext",
+        "cdf/queries/XmlaQuery.ext"
       ]
     },
     {
@@ -348,7 +352,8 @@
         "cdf/queries/BaseQuery",
         "cdf/queries/CdaQuery",
         "cdf/queries/CpkQuery",
-        "cdf/queries/LegacyQuery"
+        "cdf/queries/LegacyQuery",
+        "cdf/queries/XmlaQuery"
       ],
 
       //Exclude the modules listed bellow and their dependencies from the built file. If you want
@@ -389,7 +394,8 @@
         "cdf/dashboard/Dashboard.notifications.ext",
         "cdf/dashboard/Dashboard.storage.ext",
         "cdf/dashboard/Dashboard.views.ext",
-        "cdf/queries/CdaQuery.ext"
+        "cdf/queries/CdaQuery.ext",
+        "cdf/queries/XmlaQuery.ext"
       ]
     }
   ]


### PR DESCRIPTION
	- although it's already implicitly included, explicitly include XmlaQuery.js in the build configuration file for consistency
	- make XmlaQuery.ext (endpoint) available to other resources, by excluding it from the main Dashboard.* compiled files, including it as a minified file in the compressed folder (for consistency with all other endpoints)