### PR TITLE
[CLEANUP]

### DIFF
--- a/cdf-pentaho5/build.xml
+++ b/cdf-pentaho5/build.xml
@@ -341,7 +341,8 @@ de
 
   <target name="dist-js" depends="install-antcontrib, check-pentaho-js-build-downloaded"
           description="Creates the js distribution for js">
-    <delete dir="${js.build.output.dir}"/>
+
+    <!-- delete the dir that contains the sources to be optimized -->
     <delete dir="${js.module.script.agg.dir}"/>
     <echo message="js.module.script.agg.dir: ${js.module.script.agg.dir}"/>
     <mkdir dir="${js.module.script.agg.dir}"/>
@@ -642,7 +643,7 @@ de
 
   <target name="dist-samples" depends="init">
     <mkdir dir="${samples.stage.dir}"/>
-    <!-- copy over all the xactions within the pentaho-cdf folder -->
+    <!-- copy all sample files to the stage solution folder -->
     <copy todir="${samples.stage.dir}/plugin-samples" overwrite="true">
       <fileset dir="solution/plugin-samples"></fileset>
     </copy>

--- a/cdf-pentaho5/config/cdf.build.compile.js
+++ b/cdf-pentaho5/config/cdf.build.compile.js
@@ -7,6 +7,14 @@
   //The directory path to save the output. All relative paths are relative to the build file.
   dir: "../bin/scriptOutput",
 
+  //As of RequireJS 2.0.2, the dir above will be deleted before the
+  //build starts again. If you have a big build and are not doing
+  //source transforms with onBuildRead/onBuildWrite, then you can
+  //set keepBuildDir to true to keep the previous dir. This allows for
+  //faster rebuilds, but it could lead to unexpected errors if the
+  //built code is transformed in some way.
+  keepBuildDir: false,
+
   //By default, all modules are located relative to this path. If appDir is set, then
   //baseUrl should be specified as relative to the appDir.
   baseUrl: ".",
@@ -133,7 +141,6 @@
   //Sets up a map of module IDs to other module IDs. For more details, see
   //the http://requirejs.org/docs/api.html#config-map docs.
   //map: {},
-
 
   //List the modules that will be optimized. All their immediate and deep
   //dependencies will be included in the module's file when the build is


### PR DESCRIPTION
	- deleting ${js.build.ouput.dir} in build.xml is irrelevant, this directory is kept/recreated according to the property keepBuildDir in the optimisation config file (default is false)