### PR TITLE
[SP-1859] - Backport of PRD-5443 - PRPT - Width of Multi Value List p…

### DIFF
--- a/cdf-core/cdf/js-modules/components/SelectBaseComponent.js
+++ b/cdf-core/cdf/js-modules/components/SelectBaseComponent.js
@@ -52,7 +52,13 @@ define([
       if(placeholderText) { selectHTML += " data-placeholder='" + placeholderText + "'" ; }
 
       var size = this._getListSize(myArray);
-      if(size != null) { selectHTML += " size='" + size + "'"; }
+      if(size != null) {
+        selectHTML += " size='" + size + "'";
+        if (myArray.length > size) {
+          // PRD-5443
+          selectHTML += " style='overflow-y: scroll;' "
+        }
+      }
 
       var extPlugin = this.externalPlugin;
       switch(extPlugin) {

--- a/cdf-core/cdf/js/components/input.js
+++ b/cdf-core/cdf/js/components/input.js
@@ -97,7 +97,13 @@ var SelectBaseComponent = InputBaseComponent.extend({
     if(placeholderText) { selectHTML += " data-placeholder='" + placeholderText + "'" ; }
 
     var size = this._getListSize(myArray);
-    if(size != null) { selectHTML += " size='" + size + "'"; }
+    if(size != null) {
+      selectHTML += " size='" + size + "'";
+      if (myArray.length > size) {
+        // PRD-5443
+        selectHTML += " style='overflow-y: scroll;' "
+      }
+    }
 
     var extPlugin = this.externalPlugin;
     switch(extPlugin) {

--- a/cdf-core/test-js/components/SelectBaseComponent-spec.js
+++ b/cdf-core/test-js/components/SelectBaseComponent-spec.js
@@ -1,0 +1,77 @@
+/*!
+ * Copyright 2002 - 2015 Webdetails, a Pentaho company. All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+
+define(["cdf/components/SelectBaseComponent"], function(SelectBaseComponent) {
+
+  describe("The Select Base Component #", function() {
+
+    describe("scrolling style", function() {
+
+      var styleRegexp = "overflow-y:(\\s*)scroll";
+
+      function createPhMock() {
+        var mock = {html: function() { } };
+        spyOn(mock, 'html');
+        return mock;
+      }
+
+      function createComponent(reserved, phMock) {
+        return new SelectBaseComponent({
+          size: reserved,
+          placeholder: function() { return phMock; },
+
+          /* stubs */
+          _getParameterValue: function() { return null; },
+          _doAutoFocus: function() { },
+          _listenElement: function() { }
+        });
+      }
+
+      it("should add nothing if values' amount is less than reserved visible number", function() {
+        var reserved = 5;
+        var phMock = createPhMock();
+
+        var cmp = createComponent(reserved, phMock);
+        cmp.draw([]);
+
+        expect(phMock.html).toHaveBeenCalled();
+        expect(phMock.html.calls.argsFor(0)).not.toMatch(styleRegexp);
+      });
+
+      it("should add nothing if values' amount is equal to reserved visible number", function() {
+        var reserved = 1;
+        var phMock = createPhMock();
+
+        var cmp = createComponent(reserved, phMock);
+        cmp.draw(['1']);
+
+        expect(phMock.html).toHaveBeenCalled();
+        expect(phMock.html.calls.argsFor(0)).not.toMatch(styleRegexp);
+      });
+
+      it("should add mandatory scroll if values' amount is greater than reserved visible number", function() {
+        var reserved = 1;
+        var phMock = createPhMock();
+
+        var cmp = createComponent(reserved, phMock);
+        cmp.draw(['1', '2']);
+
+        expect(phMock.html).toHaveBeenCalled();
+        expect(phMock.html.calls.argsFor(0)).toMatch(styleRegexp);
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
…arameter box cuts short when report is viewed in Chrome (5.4 Suite)

- add 'scroll' instead of 'auto' for 'overflow-y' property when there are
  more elements that can be cramed into reserved place
- introduce 3 test cases
(cherry picked from commit 6e79d38)

@pamval, review it please. This is a backport of https://github.com/webdetails/cdf/pull/500 