### PR TITLE
[CDF-579] Integrate new Selector component into CDF

### DIFF
--- a/cdf-core/cdf/js-modules/components/filter/views/Root.js
+++ b/cdf-core/cdf/js-modules/components/filter/views/Root.js
@@ -103,7 +103,8 @@ define([
         },
         renderCollapse: function(viewModel) {
           if (viewModel.isDisabled === true) {
-            this.$('.filter-root-container').toggleClass('expanded', false).toggleClass('collapsed', true).toggleClass('alwaysExpanded', false);
+            var expand = (viewModel.alwaysExpanded === true); // we might want to start off the component as always-expanded
+            this.$('.filter-root-container').toggleClass('expanded', expand).toggleClass('collapsed', !expand).toggleClass('always-expanded', expand);
           } else if (viewModel.alwaysExpanded === true) {
             this.$('.filter-root-container').toggleClass('expanded', false).toggleClass('collapsed', false).toggleClass('always-expanded', true);
           } else if (viewModel.isCollapsed === true) {

--- a/cdf-core/cdf/js/components/filter/js/TreeFilter/views/Root.js
+++ b/cdf-core/cdf/js/components/filter/js/TreeFilter/views/Root.js
@@ -97,7 +97,8 @@
     },
     renderCollapse: function(viewModel) {
       if (viewModel.isDisabled === true) {
-        this.$('.filter-root-container').toggleClass('expanded', false).toggleClass('collapsed', true).toggleClass('alwaysExpanded', false);
+        var expand = (viewModel.alwaysExpanded === true); // we might want to start off the component as always-expanded
+        this.$('.filter-root-container').toggleClass('expanded', expand).toggleClass('collapsed', !expand).toggleClass('always-expanded', expand);
       } else if (viewModel.alwaysExpanded === true) {
         this.$('.filter-root-container').toggleClass('expanded', false).toggleClass('collapsed', false).toggleClass('always-expanded', true);
       } else if (viewModel.isCollapsed === true) {


### PR DESCRIPTION
	- fixed 'alwaysExpanded' behaviour
		- was: 'alwaysExpanded' became the active behaviour *after* the first onClick event in the component
		- now: 'alwaysExpanded' behaviour  active right at initialize/render