### PR TITLE
[BACKLOG-4055]

### DIFF
--- a/cdf-core/cdf/js-lib/cdf-core-lib-require-js-cfg.js
+++ b/cdf-core/cdf/js-lib/cdf-core-lib-require-js-cfg.js
@@ -41,7 +41,9 @@
   var isDebug = typeof document == "undefined" || document.location.href.indexOf("debug=true") > 0;
 
   var prefix = "";
-  if(typeof KARMA_RUN !== "undefined") { // unit tests
+  if(typeof ENVIRONMENT_CONFIG !== "undefined" && ENVIRONMENT_CONFIG.paths !== "undefined" && ENVIRONMENT_CONFIG.paths["cdf/lib"] !== "undefined") { // environment is configured, checking
+    prefix = requirePaths['cdf/lib'] = ENVIRONMENT_CONFIG.paths["cdf/lib"];
+  } else if(typeof KARMA_RUN !== "undefined") { // unit tests
     prefix = requirePaths['cdf/lib'] = 'bin/test-js/cdf/js/lib';
   } else if(typeof CONTEXT_PATH !== "undefined") { // production
 

--- a/cdf-core/cdf/js-modules/cdf-core-require-js-cfg.js
+++ b/cdf-core/cdf/js-modules/cdf-core-require-js-cfg.js
@@ -21,7 +21,9 @@
   var isDebug = typeof document == "undefined" || document.location.href.indexOf("debug=true") > 0;
 
   var prefix;
-  if(typeof KARMA_RUN !== "undefined") { // unit tests
+  if(typeof ENVIRONMENT_CONFIG !== "undefined" && ENVIRONMENT_CONFIG.paths !== "undefined" &&  ENVIRONMENT_CONFIG.paths["cdf"] !== "undefined") { // environment is configured, checking
+    prefix = requirePaths['cdf'] = ENVIRONMENT_CONFIG.paths["cdf"];
+  } else if(typeof KARMA_RUN !== "undefined") { // unit tests
     prefix = requirePaths['cdf'] = 'bin/test-js/cdf/js';
   } else if(typeof CONTEXT_PATH !== "undefined") { // production
 


### PR DESCRIPTION
- Adding the ability to fully configure paths for CDF in test environment.
It is done via externally include the map:
var ENVIRONMENT_CONFIG = {
  paths: {
    "cdf": "../../build-res/module-scripts/cdf/js",
    "cdf/lib": "../../build-res/module-scripts/cdf/js/lib"
  }
};
That allows an arbitrary location for the cdf code, making the require paths work no mater of there is the cdf root