### PR TITLE
[CDF-688] FilterComponent - filter.css is not the same in the legacy and amd versions of the component

### DIFF
--- a/cdf-core/cdf/js-modules/components/filter/styles/filter.css
+++ b/cdf-core/cdf/js-modules/components/filter/styles/filter.css
@@ -145,7 +145,7 @@
   padding: 0 7px 0 0;
 }
 .filter-controls .filter-control-button:last-child {
-  width: 57%;
+  width: 58%;
   padding: 0 0 0 7px;
 }
 .filter-controls .filter-control-button > .pristine {

--- a/cdf-core/cdf/js/components/filter/styles/filter.css
+++ b/cdf-core/cdf/js/components/filter/styles/filter.css
@@ -539,13 +539,16 @@
 
 .filter-busy-info {
   float: left;
+  font-size: 13px;
+  line-height: 17px;
+  color: #616161;
 }
 
 .filter-root-container .floatingBarsG{
   position: relative;
   width: 14px;
   height: 17px;
-  margin: 0;
+  margin: 0 9px 0 6px;
   float: left;
 }
 

--- a/cdf-core/resource/resources/style/template.css
+++ b/cdf-core/resource/resources/style/template.css
@@ -15,7 +15,7 @@
   src: local('Open Sans Light'), local('OpenSans-Light'), url('http://themes.googleusercontent.com/static/fonts/opensans/v4/DXI1ORHCpsQm3Vp6mXoaTXhCUOGz7vYGh680lGh-uXM.woff') format('woff');
 }
 
-body {
+body .webdetailsWrapper {
 	margin-top: 10px;
 	background-color: #f6f7f8;
 	min-height: 900px;


### PR DESCRIPTION
    - made legacy and amd versions of filter.css equal, according to the UX team's guidelines
    - made template.css body rules more specific so AMD samples don't have overridden styles (e.g. font-family overridden by screen.css in a blueprint dashboard)