### PR TITLE
[TEST]

### DIFF
--- a/core-js/src/test/javascript/config/karma.ci.conf.js
+++ b/core-js/src/test/javascript/config/karma.ci.conf.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2015 Webdetails, a Pentaho company. All rights reserved.
+ * Copyright 2002 - 2016 Webdetails, a Pentaho company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -36,7 +36,7 @@ module.exports = function(config) {
       'src/test/javascript/config/karma.main.config.js',
       {pattern: 'src/test/javascript/cdf/**/*.ext.js', included: true},
       // fix 404 messages
-      {pattern: 'src/test/javascript/cdf/dashboard/*.properties', watched: false, included: true, served: true},
+      {pattern: 'src/test/javascript/cdf/dashboard/*.properties', watched: false, included: false, served: true},
       {pattern: 'target/test-javascript/**/*.png', watched: false, included: false, served: true},
       {pattern: 'target/test-javascript/**/*.gif', watched: false, included: false, served: true},
       {pattern: 'target/test-javascript/**/*.svg', watched: false, included: false, served: true}

--- a/core-js/src/test/javascript/config/karma.conf.js
+++ b/core-js/src/test/javascript/config/karma.conf.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2015 Webdetails, a Pentaho company. All rights reserved.
+ * Copyright 2002 - 2016 Webdetails, a Pentaho company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -36,7 +36,7 @@ module.exports = function(config) {
       'src/test/javascript/config/karma.main.config.js',
       {pattern: 'src/test/javascript/cdf/**/*.ext.js', included: true},
       // fix 404 messages
-      {pattern: 'src/test/javascript/cdf/dashboard/*.properties', watched: false, included: true, served: true},
+      {pattern: 'src/test/javascript/cdf/dashboard/*.properties', watched: false, included: false, served: true},
       {pattern: 'target/test-javascript/**/*.png', watched: false, included: false, served: true},
       {pattern: 'target/test-javascript/**/*.gif', watched: false, included: false, served: true},
       {pattern: 'target/test-javascript/**/*.svg', watched: false, included: false, served: true}

--- a/pentaho-js/src/test/javascript/config/karma.ci.conf.js
+++ b/pentaho-js/src/test/javascript/config/karma.ci.conf.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2015 Webdetails, a Pentaho company. All rights reserved.
+ * Copyright 2002 - 2016 Webdetails, a Pentaho company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -28,6 +28,7 @@ module.exports = function(config) {
       {pattern: 'target/test-javascript/lib/**/*.css', included: false},
       {pattern: 'target/test-javascript/lib/**/*.js', included: false},
       {pattern: 'target/dependency/ccc/amd/**/*.js', included: false},
+      {pattern: 'target/dependency/ccc/amd/**/*.css', included: false},
       {pattern: 'src/test/javascript/cdf/**/*.ext.js', included: true},
       'src/test/javascript/config/context.js',
       {pattern: 'src/test/javascript/cdf/**/*.js', included: false},
@@ -36,10 +37,10 @@ module.exports = function(config) {
       'target/test-javascript/cdf-pentaho-require-js-cfg.js',
       'src/test/javascript/config/karma.main.config.js',
       // fix 404 messages
-      {pattern: 'src/test/javascript/cdf/dashboard/*.properties', watched: false, included: true, served: true},
-      {pattern: 'target/test-javascript/cdf/**/*.png', watched: false, included: false, served: true},
-      {pattern: 'target/test-javascript/cdf/**/*.gif', watched: false, included: false, served: true},
-      {pattern: 'target/test-javascript/cdf/**/*.svg', watched: false, included: false, served: true}
+      {pattern: 'src/test/javascript/cdf/dashboard/*.properties', watched: false, included: false, served: true},
+      {pattern: 'target/test-javascript/**/*.png', watched: false, included: false, served: true},
+      {pattern: 'target/test-javascript/**/*.gif', watched: false, included: false, served: true},
+      {pattern: 'target/test-javascript/**/*.svg', watched: false, included: false, served: true}
     ],
 
     preprocessors: {

--- a/pentaho-js/src/test/javascript/config/karma.conf.js
+++ b/pentaho-js/src/test/javascript/config/karma.conf.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2015 Webdetails, a Pentaho company. All rights reserved.
+ * Copyright 2002 - 2016 Webdetails, a Pentaho company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -24,18 +24,23 @@ module.exports = function(config) {
     files: [
       {pattern: 'target/test-javascript/cdf/**/*.css', included: false},
       {pattern: 'target/test-javascript/cdf/**/*.js', included: false},
+      {pattern: 'target/test-javascript/cdf/**/*.html', included: false},
       {pattern: 'target/test-javascript/lib/**/*.css', included: false},
       {pattern: 'target/test-javascript/lib/**/*.js', included: false},
       {pattern: 'target/dependency/ccc/amd/**/*.js', included: false},
+      {pattern: 'target/dependency/ccc/amd/**/*.css', included: false},
       {pattern: 'src/test/javascript/cdf/**/*.ext.js', included: true},
       'src/test/javascript/config/context.js',
       {pattern: 'src/test/javascript/cdf/**/*.js', included: false},
       'target/test-javascript/cdf-core-require-js-cfg.js',
+      'target/test-javascript/cdf-core-lib-require-js-cfg.js',
+      'target/test-javascript/cdf-pentaho-require-js-cfg.js',
       'src/test/javascript/config/karma.main.config.js',
       // fix 404 messages
-      {pattern: 'target/test-javascript/cdf/**/*.png', watched: false, included: false, served: true},
-      {pattern: 'target/test-javascript/cdf/**/*.gif', watched: false, included: false, served: true},
-      {pattern: 'target/test-javascript/cdf/**/*.svg', watched: false, included: false, served: true}
+      {pattern: 'src/test/javascript/cdf/dashboard/*.properties', watched: false, included: false, served: true},
+      {pattern: 'target/test-javascript/**/*.png', watched: false, included: false, served: true},
+      {pattern: 'target/test-javascript/**/*.gif', watched: false, included: false, served: true},
+      {pattern: 'target/test-javascript/**/*.svg', watched: false, included: false, served: true}
     ],
 
     // test results reporter to use


### PR DESCRIPTION
	- added missing dependencies
	- set included pattern object property to false for i18n *.properties files, no need to add <script> tags in the browser to load them (see http://karma-runner.github.io/0.13/config/files.html)