### PR TITLE
[CDF-827] - Added documentation for inner objects on Popup components

### DIFF
--- a/core-js/src/doc/javascript/config/customPlugins/defineTags.js
+++ b/core-js/src/doc/javascript/config/customPlugins/defineTags.js
@@ -41,6 +41,16 @@ exports.defineTags = function (dictionary) {
     }
   });
 
+  dictionary.defineTag('code', {
+    keepsWhitespace: true,
+    removesIndent: true,
+    mustHaveValue: true,
+    onTagged: function(doclet, tag) {
+      doclet.codeExamples = doclet.codeExamples || [];
+      doclet.codeExamples.push(tag.value);
+    }
+  });
+
   //TODO: Check what this is doing in the default tag
   /*function parseTypeText(text) {
     var tagType = jsdoc.tag.type.parse(text, false, true);

--- a/core-js/src/doc/javascript/template/publish.js
+++ b/core-js/src/doc/javascript/template/publish.js
@@ -81,18 +81,7 @@ function getSignatureAttributes(item) {
 }
 
 function updateItemName(item) {
-    var attributes = getSignatureAttributes(item);
     var itemName = item.name || '';
-
-    if (item.variable) {
-        itemName = '&hellip;' + itemName;
-    }
-
-    if (attributes && attributes.length) {
-        itemName = util.format( '%s<span class="signature-attributes">%s</span>', itemName,
-            attributes.join(', ') );
-    }
-
     return itemName;
 }
 
@@ -422,6 +411,21 @@ exports.publish = function(taffyData, opts, tutorials) {
                 return {
                     caption: caption || '',
                     code: code || example
+                };
+            });
+        }
+        if (doclet.codeExamples) {
+            doclet.codeExamples = doclet.codeExamples.map(function(codeExample) {
+                var caption, code;
+
+                if (codeExample.match(/^\s*<caption>([\s\S]+?)<\/caption>(\s*[\n\r])([\s\S]+)$/i)) {
+                    caption = RegExp.$1;
+                    code = RegExp.$3;
+                }
+
+                return {
+                    caption: caption || '',
+                    code: code || codeExample
                 };
             });
         }

--- a/core-js/src/doc/javascript/template/publish.js
+++ b/core-js/src/doc/javascript/template/publish.js
@@ -449,6 +449,35 @@ exports.publish = function(taffyData, opts, tutorials) {
         }
     });
 
+    /*
+     * Handle the defaul values for non optional properties correctly. 
+     * 
+     */
+    data().each(function(doclet) {
+        if (doclet.properties) {
+            doclet.properties = doclet.properties.map(function(property) {
+                var separator = " - ",
+                    separatorLength = separator.length;
+                
+                var defaultvalue = property.defaultvalue;
+                var description = property.description;
+
+                if( property.defaultvalue !== 'undefined' && !property.optional && description.indexOf(separator) > 0) {
+                    var index = description.indexOf(separator);
+                    defaultvalue += " " + description.substr(separatorLength, index-separatorLength);
+                    description = "<p>" + description.substr(index + separatorLength, description.length);
+                }
+
+                return {
+                    defaultvalue: defaultvalue,
+                    description: description,
+                    type: property.type,
+                    name: property.name
+                }  
+            });                  
+        }
+    });
+
     // update outdir if necessary, then create outdir
     var packageInfo = ( find({kind: 'package'}) || [] ) [0];
     if (packageInfo && packageInfo.name) {

--- a/core-js/src/doc/javascript/template/tmpl/code.tmpl
+++ b/core-js/src/doc/javascript/template/tmpl/code.tmpl
@@ -1,0 +1,8 @@
+<?js
+    var data = obj;
+    var self = this;
+?>
+<?js if (data.caption) { ?>
+	<p class="code-caption"><?js= data.caption ?></p>
+<?js } ?>
+<pre class="prettyprint"><code><?js= self.htmlsafe(data.code) ?></code></pre>

--- a/core-js/src/doc/javascript/template/tmpl/container.tmpl
+++ b/core-js/src/doc/javascript/template/tmpl/container.tmpl
@@ -20,27 +20,6 @@
     <article id="elm-main-content" class="elm-content-container">
         <section class="mt-content-container">
             <div id="pageText">
-                <p><input id="privateCheckbox" name="private" type="checkbox" value="Private" checked/>Private
-                <script type="text/javascript">
-                    $("#privateCheckbox").click(function(){
-                        $(".private").toggle();
-                    });
-                </script>
-
-                <input id="inheritedCheckbox" name="inherited" type="checkbox" value="Inherited" checked/>Inherited
-                <script type="text/javascript">
-                    $("#inheritedCheckbox").click(function(){
-                        $(".inherited").toggle();
-                    });
-                </script>
-
-                <input id="deprecatedCheckbox" name="deprecated" type="checkbox" value="Deprecated" checked/>Deprecated<p>
-                <script type="text/javascript">
-                    $("#deprecatedCheckbox").click(function(){
-                        $(".deprecated").toggle();
-                    });
-                </script>
-
                 <div class="mt-page-summary">
                     <div class="mt-page-overview"></div>
                 </div>
@@ -58,7 +37,7 @@
                         <p><?js= doc.classdesc ?></p>
                     <?js } ?>
                 <?js } ?>
-                    
+
                 <p>
                     <strong>Source: </strong>WHAT WE WILL DO HERE???????
                 </p>
@@ -66,6 +45,9 @@
                 <?js= self.partial('amd.tmpl', doc) ?>
 
                 <?js if (doc.kind === 'class') { ?>
+                    <?js if(doc.scope != "static") { ?>
+                        <h3>Constructor</h3>
+                    <?js } ?>
                     <?js= self.partial('method-details.tmpl', doc) ?>
                 <?js } else { ?>
                     <?js if (doc.description) { ?>
@@ -78,11 +60,11 @@
                         <h3>Example<?js= doc.examples.length > 1? 's':'' ?></h3>
                         <?js= self.partial('examples.tmpl', doc.examples) ?>
                     <?js } ?>
-                <?js } ?> 
+                <?js } ?>
 
                 <?js if (doc.augments && doc.augments.length) { ?>
                     <p class="h3">Extends </p>
-                    
+
 
                     <?js= self.partial('augments.tmpl', doc) ?>
                 <?js } ?>
@@ -93,9 +75,8 @@
                     <ul><?js doc.requires.forEach(function(r) { ?>
                         <li><?js= self.linkto(r, r) ?></li>
                     <?js }); ?></ul>
-                <?js } ?> 
-
-                <h3>Constructor</h3>
+                <?js } ?>
+                
 
                 <?js var members = self.find({kind: 'member', memberof: isGlobalPage ? {isUndefined: true} : doc.longname});
                 if (isGlobalPage && members && members.length && members.forEach) {
@@ -106,7 +87,7 @@
                 if (members && members.length && members.forEach) { ?>
                     <h3>Members</h3>
                     <?js= self.partial('members-summary.tmpl', members) ?>
-                <?js } ?> 
+                <?js } ?>
 
                 <?js var methods = self.find({kind: 'function', memberof: isGlobalPage ? {isUndefined: true} : doc.longname});
                 if (methods && methods.length && methods.forEach) { ?>
@@ -157,7 +138,7 @@
                         <?js= self.partial('method-details.tmpl', m) ?>
                     <?js }); ?>
                 <?js } ?>
-            
+
                 <?js var typedefs = self.find({kind: 'typedef', memberof: isGlobalPage ? {isUndefined: true} : doc.longname});
                 if (typedefs && typedefs.length && typedefs.forEach) { ?>
                     <h3>Type Definitions</h3>
@@ -178,7 +159,7 @@
                         <?js= self.partial('method-details.tmpl', e) ?>
                     <?js }); ?>
                 <?js } ?>
-            
+
         </section>
     </article>
 <?js } ?>

--- a/core-js/src/doc/javascript/template/tmpl/details.tmpl
+++ b/core-js/src/doc/javascript/template/tmpl/details.tmpl
@@ -107,11 +107,11 @@ if (data.defaultvalue && (data.defaultvaluetype === 'object' || data.defaultvalu
         </ul></dd>
     <?js } ?>
 
+
     <?js if (data.meta) {?>
-    <!--<dt class="tag-source">Source:</dt>
-    <dd class="tag-source"><ul class="dummy"><li>
-        <?js= self.linkto(meta.shortpath) ?>, <?js= self.linkto(meta.shortpath, 'line ' + meta.lineno, null, 'line' + meta.lineno) ?>
-    </li></ul></dd>-->
+    <p>
+        <strong>Source: </strong> <?js= self.linkto(meta.shortpath) ?>, <?js= self.linkto(meta.shortpath, 'line ' + meta.lineno, null, 'line' + meta.lineno) ?>
+    </p>
     <?js } ?>
 
     <?js if (data.tutorials && tutorials.length) {?>

--- a/core-js/src/doc/javascript/template/tmpl/member-details.tmpl
+++ b/core-js/src/doc/javascript/template/tmpl/member-details.tmpl
@@ -30,12 +30,12 @@ var self = this;
                 <?js } ?>
                 </p>
 
+                <?js= this.partial('details.tmpl', data) ?>
+
                 <?js if (data.codeExamples) { ?>
                     <h5>Code</h5>
                     <?js= this.partial('examples.tmpl', data.codeExamples) ?>
                 <?js } ?>
-
-                <?js= this.partial('details.tmpl', data) ?>
 
                 <?js if (data.fires && data.fires.length) { ?>
                     <h5>Fires:</h5>

--- a/core-js/src/doc/javascript/template/tmpl/member-details.tmpl
+++ b/core-js/src/doc/javascript/template/tmpl/member-details.tmpl
@@ -11,7 +11,10 @@ var self = this;
     <thead>
         <tr>
             <th>
-                <?js= id ?>: <code> <?js= self.partial('type.tmpl', data.type.names) ?> </code>
+                <?js= id ?> 
+                <?js if(data.type) { ?>
+                    : <code> <?js= self.partial('type.tmpl', data.type.names) ?> </code>
+                <?js } ?>    
                 <?js= self.partial('modifiers.tmpl', data) ?>  
             </th>
         </tr>    
@@ -27,33 +30,23 @@ var self = this;
                 <?js } ?>
                 </p>
 
-                <?js if (data.meta) {?>
-                    <p>
-                        <strong>Source: </strong> <?js= self.linkto(meta.shortpath) ?>, <?js= self.linkto(meta.shortpath, 'line ' + meta.lineno, null, 'line' + meta.lineno) ?>
-                    </p>
-                <?js } ?>                
-                <?js if (data.inherited && data.inherits && !data.overrides) { ?>
-                    <p>
-                        <strong>Inherited from: </strong><?js= this.linkto(data.inherits, this.htmlsafe(data.inherits)) ?>
-                    </p>
+                <?js if (data.codeExamples) { ?>
+                    <h5>Code</h5>
+                    <?js= this.partial('examples.tmpl', data.codeExamples) ?>
                 <?js } ?>
-                <?js if (data.defaultvalue) {?>
-                    <p>
-                        <strong>Default Value: </strong> <?js= data.defaultvalue ?>
-                    </p>
-                <?js } ?>
+
                 <?js= this.partial('details.tmpl', data) ?>
 
-                <?js if (data.fires && fires.length) { ?>
+                <?js if (data.fires && data.fires.length) { ?>
                     <h5>Fires:</h5>
                     <ul><?js fires.forEach(function(f) { ?>
                         <li><?js= self.linkto(f) ?></li>
                     <?js }); ?></ul>
                 <?js } ?>
 
-                <?js if (data.examples && examples.length) { ?>
-                    <h5>Example<?js= examples.length > 1? 's':'' ?></h5>
-                    <?js= this.partial('examples.tmpl', examples) ?>
+                <?js if (data.examples && data.examples.length) { ?>
+                    <h5>Example<?js= data.examples.length > 1? 's':'' ?></h5>
+                    <?js= this.partial('examples.tmpl', data.examples) ?>
                 <?js } ?>
             </td>
         </tr>

--- a/core-js/src/doc/javascript/template/tmpl/members-summary.tmpl
+++ b/core-js/src/doc/javascript/template/tmpl/members-summary.tmpl
@@ -19,9 +19,12 @@ var self = this;
             ?>
             <tr class="<?js= member.access != null ? member.access : 'public' ?> <?js= member.deprecated ? 'deprecated' : '' ?> <?js= member.inherited ? 'inherited' : '' ?>">
                 <td> 
-                    <a href="#<?js= member.name + '_anchor' ?>"> <?js= member.name ?> </a>
-                    :
-                    <?js= self.partial('type.tmpl', member.type.names) ?> 
+                    <a href="#<?js= member.name + '_anchor' ?>"> 
+                        <?js= member.name ?> 
+                    </a>
+                    <?js if(member.type) { ?>
+                        : <code> <?js= self.partial('type.tmpl', member.type.names) ?> </code>
+                    <?js } ?>    
                     <?js= self.partial('modifiers.tmpl', member) ?>  
                 </td>
                 <td> <?js= member.summary ?> </td>

--- a/core-js/src/doc/javascript/template/tmpl/method-details.tmpl
+++ b/core-js/src/doc/javascript/template/tmpl/method-details.tmpl
@@ -11,7 +11,7 @@ var self = this;
     <thead>
         <tr>
             <th>
-                <?js= data.name + (data.signature || '')  ?>
+                <?js= data.name + (data.kind === "class" && data.scope === "static" ? '': data.signature || '' )  ?>
                 <?js if (data.returns && data.returns.length) { ?>
                 :
                     <?js data.returns.forEach(function(r, i) { ?>
@@ -33,20 +33,12 @@ var self = this;
                     <?js= data.description ?>
                 <?js } ?>
                 </p>
-
-                <?js if (data.meta) {?>
-                    <p>
-                        <strong>Source: </strong> <?js= self.linkto(meta.shortpath) ?>, <?js= self.linkto(meta.shortpath, 'line ' + meta.lineno, null, 'line' + meta.lineno) ?>
-                    </p>
-                <?js } ?>  
-                <?js if (data.inherited && data.inherits && !data.overrides) { ?>
-                    <p>
-                        <strong>Inherited from: </strong><?js= this.linkto(data.inherits, this.htmlsafe(data.inherits)) ?>
-                    </p>
-                <?js } ?>
+                
                 <?js if (data.params && params.length) { ?>
                     <?js= this.partial('params.tmpl', params) ?>
                 <?js } ?>
+
+                <?js= this.partial('details.tmpl', data) ?>
 
                 <?js if (data.fires && fires.length) { ?>
                     <p><strong>Fires:</strong>

--- a/core-js/src/main/javascript/cdf/dashboard/Popups.js
+++ b/core-js/src/main/javascript/cdf/dashboard/Popups.js
@@ -29,12 +29,10 @@ define([
   return /** @lends cdf.dashboard.Popups */ {
 
     /**
+     * @class
      * @summary The Ok Popup
      * @classdesc <p>The Ok Popup object containing the default values for a success notification popup.</p>
      *            <p>On Button click, the Popup is closed.</p> 
-     *
-     * @class
-     *
      * @example
      * <div class='cdfPopup'>
      *   <div class='cdfPopupHeader'>Title</div>
@@ -82,9 +80,9 @@ define([
        * @description The Popup default properties, with the properties applied during the template render
        * @type {Object}
        * 
-       * @property {String} header=Title The Header of the popup
-       * @property {String} desc=Description Text The description of the popup
-       * @property {String} button=Button Text The text on the button used to close the popup
+       * @property {String} header=Title The Header of the popup.
+       * @property {String} desc=Description Text - The description of the popup.
+       * @property {String} button=Button Text - The text on the button used to close the popup. 
        * @property {Function} callback Callback function executed when the button is clicked
        */
       defaults: {
@@ -151,11 +149,10 @@ define([
     },
 
     /**
+     * @class
      * @summary The Error Notification Popup
      * @classdesc <p>The Error Notification Popup object containing the default values for a error notification
-     *            popup.</p>
-     *           
-     * @class
+     *            popup.</p>     
      *
      * @example
      * <div class='cdfNotification component small>
@@ -196,8 +193,8 @@ define([
        * @description The Popup default properties, with the properties applied during the template render.
        *
        * @type {Object}
-       * @property {String} title=Component Error Error popup default values.
-       * @property {String} desc=Error processing component.
+       * @property {String} title=Component Error - Title of the Error message
+       * @property {String} desc=Error processing component - The Error message
       */
       defaults: {
         title: "Component Error",
@@ -206,7 +203,8 @@ define([
 
       /**
        * @summary Renders the Popup
-       * @description <p>Renders the Popup based on the object containing the properties to apply to the Mustache template.</p>
+       * @description <p>Renders the Popup based on the object containing the properties to apply to the Mustache 
+       *              template.</p>
        *              <p>If the component has width smaller than 300, the css class small is added.</p>
        *
        * @param {Element|Selector} ph The Html Element Object or the 
@@ -225,12 +223,10 @@ define([
     },
 
     /**
+     * @class
      * @summary The Error Notification Growl Popup
      * @classdesc <p>The Error Notification Growl Popup object containing the default values for a error
      *            notification growl popup.</p>
-     *           
-     * @class
-     *
      * @example
      * <div class='cdfNotification growl'>
      *   <div class='cdfNotificationBody'>
@@ -278,7 +274,7 @@ define([
        * @type {Object}
        *
        * @property {String} title=Title The Title of the popup
-       * @property {String} desc=Default CDF notification. The description of the popup
+       * @property {String} desc=Default CDF notification - The description of the popup
        * @property {Number} timeout=4000 The timeout for the popup
        * @property {Function} onUnblock Callback function called when onUnblock from 
        *                                {@link http://malsup.com/jquery/block/|jQuery.blockUI} is called

--- a/core-js/src/main/javascript/cdf/dashboard/Popups.js
+++ b/core-js/src/main/javascript/cdf/dashboard/Popups.js
@@ -22,24 +22,54 @@ define([
   /**
    * @class cdf.dashboard.Popups
    * @amd cdf/dashboard/Popups
-   * @classdesc A static class containing pre-built error and success popups.
-   *            Each exposed popup is an object with a _render_ method that can be called to show the popup.
+   * @classdesc <p>A static class containing pre-built error and success popups.</p>
+   *            <p>Each exposed popup is an object with a _render_ method that can be called to show the popup with 
+   *            some default values for each case.</p>
    */
   return /** @lends cdf.dashboard.Popups */ {
 
     /**
-     * Object containing the default values for a success notification popup.
+     * @summary The Ok Popup
+     * @classdesc <p>The Ok Popup object containing the default values for a success notification popup.</p>
+     *            <p>On Button click, the Popup is closed.</p> 
      *
-     * @type {Object}
-     * @property {string}   template    Ok popup template.
-     * @property {Object}   defaults    Ok popup default values.
-     * @property {Object}   $el         A {@link http://api.jquery.com/|jQuery} object referencing a DOM element.
-     * @property {function} show        Function that shows the ok popup.
-     * @property {function} hide        Function that hides the ok popup.
-     * @property {function} render      Function that renders the ok popup.
-     * @property {boolean}  firstRender Flag indicating first render.
+     * @class
+     *
+     * @example
+     * <div class='cdfPopup'>
+     *   <div class='cdfPopupHeader'>Title</div>
+     *   <div class='cdfPopupBody'>
+     *     <div class='cdfPopupDesc'>Description Text</div>
+     *     <div class='cdfPopupButton'>Button Text</div>
+     *   </div>
+     * </div>
+     * 
      */
-    okPopup: {
+    okPopup: /** @lends cdf.dashboard.Popups.okPopup */{
+      /**
+       * @summary <code>Boolean</code> for component render state
+       * @description <code>Boolean</code> property used to define if the component was rendered or not 
+       * @type {Boolean}
+       * @private
+       */
+      _firstRender: true,
+
+      /**
+       * @summary The template of the Popup
+       * @description <p>The {@link https://mustache.github.io/|Mustache} template of the Ok Popup.</p>
+       *              <p>It has an header, description and a button. The default values for each of the template
+       *              variables are stored in {@link defaults} object.</p>
+       * @type {String}
+       *   
+       * @code 
+       * <div class='cdfPopup'>
+       *   <div class='cdfPopupHeader'>{{{header}}}</div>
+       *   <div class='cdfPopupBody'>
+       *     <div class='cdfPopupDesc'>{{{desc}}}</div>
+       *     <div class='cdfPopupButton'>{{{button}}}</div>
+       *   </div>
+       * </div>
+       */
       template: "<div class='cdfPopup'>" +
                 "  <div class='cdfPopupHeader'>{{{header}}}</div>" +
                 "  <div class='cdfPopupBody'>" +
@@ -47,6 +77,16 @@ define([
                 "    <div class='cdfPopupButton'>{{{button}}}</div>" +
                 "  </div>" +
                 "</div>",
+      /**
+       * @summary The Popup default properties
+       * @description The Popup default properties, with the properties applied during the template render
+       * @type {Object}
+       * 
+       * @property {String} header=Title The Header of the popup
+       * @property {String} desc=Description Text The description of the popup
+       * @property {String} button=Button Text The text on the button used to close the popup
+       * @property {Function} callback Callback function executed when the button is clicked
+       */
       defaults: {
         header: "Title",
         desc: "Description Text",
@@ -55,45 +95,95 @@ define([
           return true
         }
       },
+
+      /**
+       * @summary The {@link http://api.jquery.com/Types/#jQuery|jQuery} element
+       * @description The {@link http://api.jquery.com/Types/#jQuery|jQuery} element that holds the popup's content
+       * @type {jQuery}
+       */
       $el: undefined,
+
+      /**
+       * @summary Shows the popup
+       * @description <p>Shows the popup based on the {@link $el} object.</p>
+       *              <p>If the popup is rendering for the first time or if show is called with the opts para then 
+       *              the render is called.</p>
+       * @param {Object} [opts] Options object used to call the render 
+       */
       show: function(opts) {
-        if(opts || this.firstRender) {
+        if(opts || this._firstRender) {
           this.render(opts);
         }
         this.$el.show();
       },
+
+      /**
+       * @summary Hides the popup
+       * @description Hides the popup, based on the {@link #$el} element
+       */
       hide: function() {
         this.$el.hide();
       },
+
+      /**
+       * @summary Renders the Popup
+       * @description <p>Renders the Popup based on the object containing the properties to apply to the Mustache 
+       *              template.</p>
+       *              <p>When the component is rendered, it gets hidden and appended to the body.
+       * @param {Object} [newOpts] Options object used to extend the default object. This is used to assign values 
+       *                           to the properties that define the content of the component.
+       */
       render: function(newOpts) {
         var opts = _.extend({} , this.defaults, newOpts);
         var myself = this;
-        if(this.firstRender) {
+        if(this._firstRender) {
           this.$el = $('<div/>').addClass('cdfPopupContainer')
             .hide()
             .appendTo('body');
-          this.firstRender = false;
+          this._firstRender = false;
         }
         this.$el.empty().html(Mustache.render(this.template, opts));
         this.$el.find('.cdfPopupButton').click(function() {
           opts.callback();
           myself.hide();
         });
-      },
-      firstRender: true
+      }
     },
 
-    // Error information divs
-
     /**
-     * Object containing the default values for an error notification popup.
+     * @summary The Error Notification Popup
+     * @classdesc <p>The Error Notification Popup object containing the default values for a error notification
+     *            popup.</p>
+     *           
+     * @class
      *
-     * @type {Object}
-     * @property {string}   template Error popup template.
-     * @property {Object}   defaults Error popup default values.
-     * @property {function} render   Function that renders the error popup.
+     * @example
+     * <div class='cdfNotification component small>
+     *   <div class='cdfNotificationBody'>
+     *     <div class='cdfNotificationImg'>&nbsp;</div>
+     *     <div class='cdfNotificationTitle' title='Component Error'>Component Error</div>
+     *     <div class='cdfNotificationDesc' title='Error processing component.'>Error processing component.</div>
+     *   </div>
+     * </div>
      */
     notificationsComponent: {
+      /**
+       * @summary The template of the Popup
+       * @description <p>The {@link https://mustache.github.io/|Mustache} template of the Error Notification Popup.
+       *              </p>
+       *              <p>It has an title and description. The default values for each of the template variables are 
+       *              stored in {@link defaults} object.</p>
+       * @type {String}
+       *   
+       * @code 
+       * <div class='cdfNotification component {{#isSmallComponent}}small{{/isSmallComponent}}>
+       *   <div class='cdfNotificationBody'>
+       *     <div class='cdfNotificationImg'>&nbsp;</div>
+       *     <div class='cdfNotificationTitle' title='{{title}}'>{{{title}}}</div>
+       *     <div class='cdfNotificationDesc' title='{{desc}}'>{{{desc}}}</div>
+       *   </div>
+       * </div>
+       */
       template: "<div class='cdfNotification component {{#isSmallComponent}}small{{/isSmallComponent}}'>" +
                 "  <div class='cdfNotificationBody'>" +
                 "    <div class='cdfNotificationImg'>&nbsp;</div>" +
@@ -101,10 +191,30 @@ define([
                 "    <div class='cdfNotificationDesc' title='{{desc}}'>{{{desc}}}</div>" +
                 "  </div>" +
                 "</div>" ,
+      /**
+       * @summary The Popup default properties 
+       * @description The Popup default properties, with the properties applied during the template render.
+       *
+       * @type {Object}
+       * @property {String} title=Component Error Error popup default values.
+       * @property {String} desc=Error processing component.
+      */
       defaults: {
         title: "Component Error",
         desc: "Error processing component."
       },
+
+      /**
+       * @summary Renders the Popup
+       * @description <p>Renders the Popup based on the object containing the properties to apply to the Mustache template.</p>
+       *              <p>If the component has width smaller than 300, the css class small is added.</p>
+       *
+       * @param {Element|Selector} ph The Html Element Object or the 
+       *                              {@link http://api.jquery.com/Types/#Selector|jQuery Selector} for the object. 
+       *                              This is the container that will hold the content of the component
+       * @param {Object} [newOpts] Options object used to extend the default object. This is used to assign values 
+       *                           to the properties that define the content of the component.
+       */
       render: function(ph, newOpts) {
         var opts = _.extend({}, this.defaults, newOpts);
         opts.isSmallComponent = ($(ph).width() < 300);
@@ -115,21 +225,75 @@ define([
     },
 
     /**
-     * Object containing the default values for a Growl notification popup.
+     * @summary The Error Notification Growl Popup
+     * @classdesc <p>The Error Notification Growl Popup object containing the default values for a error
+     *            notification growl popup.</p>
+     *           
+     * @class
      *
-     * @type {Object}
-     * @property {string}   template    Growl popup template.
-     * @property {Object}   defaults    Growl popup default values.
-     * @property {function} render      Function that renders the growl popup.
-     * @property {boolean}  firstRender Flag indicating first render.
+     * @example
+     * <div class='cdfNotification growl'>
+     *   <div class='cdfNotificationBody'>
+     *     <h1 class='cdfNotificationTitle' title='Title'>Title</h1>
+     *     <h2 class='cdfNotificationDesc' title='Default CDF notification.'>Default CDF notification.</h2>
+     *   </div>
+     * </div>
      */
     notificationsGrowl: {
+      /**
+       * @summary <code>Boolean</code> for component render state
+       * @description <code>Boolean</code> property used to define if the component was rendered or not 
+       * @type {Boolean}
+       * @private
+       */
+      _firstRender: true,
+
+      /**
+       * @summary The template of the Popup
+       * @description <p>The {@link https://mustache.github.io/|Mustache} template of the Error Notification 
+       *              Popup.</p>
+       *              <p>It has an title and description. The default values for each of the template variables are
+       *              stored in {@link defaults} object.</p>
+       * @type {String}
+       *   
+       * @code 
+       * <div class='cdfNotification growl'>
+       *   <div class='cdfNotificationBody'>
+       *     <h1 class='cdfNotificationTitle' title='{{title}}'>{{{title}}}</h1>
+       *     <h2 class='cdfNotificationDesc' title='{{desc}}'>{{{desc}}}</h2>
+       *   </div>
+       * </div>
+       */
       template: "<div class='cdfNotification growl'>" +
                 "  <div class='cdfNotificationBody'>" +
                 "    <h1 class='cdfNotificationTitle' title='{{title}}'>{{{title}}}</h1>" +
                 "    <h2 class='cdfNotificationDesc' title='{{desc}}'>{{{desc}}}</h2>" +
                 "  </div>" +
                 "</div>" ,
+
+      /**
+       * @summary The Popup default properties
+       * @description <p>The Popup default properties, with the properties applied during the template render.</p>
+       *              <p>More info about some of the properties used detailed below.</p>
+       * @type {Object}
+       *
+       * @property {String} title=Title The Title of the popup
+       * @property {String} desc=Default CDF notification. The description of the popup
+       * @property {Number} timeout=4000 The timeout for the popup
+       * @property {Function} onUnblock Callback function called when onUnblock from 
+       *                                {@link http://malsup.com/jquery/block/|jQuery.blockUI} is called
+       * @property {Object} css An object wit the {@link http://malsup.com/jquery/block/|jQuery.blockUI} default
+       *                        options
+       * @property {String} css.position=Absolute The default popup css position value
+       * @property {String} css.width=100% The default popup css width value
+       * @property {String} css.top=10px The default popup css top value
+       * @property {Boolean} showOverlay=false Boolean flag to control wether the overlay is shown or not
+       * @property {Number} fadeIn=700 Time in milliseconds to show the Growl Popup
+       * @property {Number} fadeOut=1000 Time in milliseconds to hide the Growl Popup
+       * @property {Boolean} centerY=false Boolean to force the Growl Popup to now be centered in the Y axis
+       * 
+       * @see {@link http://malsup.com/jquery/block/|jQuery.blockUI}
+       */
       defaults: {
         title: 'Title',
         desc: 'Default CDF notification.',
@@ -145,6 +309,19 @@ define([
         fadeOut: 1000,
         centerY: false
       },
+
+      /**
+       * @summary Renders the Popup
+       * @description <p>Renders the Popup based on the object containing the properties to apply to the Mustache 
+       *              template.</p>
+       *              <p>If the render function is called for the first time, then the component is rendered and 
+       *              attached in the body of the page. Otherwise, the component is shown, calling the 
+       *              {@link http://malsup.com/jquery/block/|jQuery.blockUI}.
+       *              {@link http://malsup.com/jquery/block/#element|block} function with the defaults extended 
+       *              with the newOpts argument, to allow user costumizations</p>
+       *
+       * @param {Object} [newOpts] Options object used to extend the default object. This is used to assign values to the properties that define the content of the component.
+       */
       render: function(newOpts) {
         var opts = _.extend({}, this.defaults, newOpts),
             $m = $(Mustache.render(this.template, opts)),
@@ -155,13 +332,12 @@ define([
           myself.$el.hide();
           outerUnblock.call(this);
         };
-        if(this.firstRender) {
+        if(this._firstRender) {
           this.$el = $('<div/>').addClass('cdfNotificationContainer').hide().appendTo('body');
-          this.firstRender = false;
+          this._firstRender = false;
         }
         this.$el.show().block(opts);
-      },
-      firstRender: true
+      } 
     }
   };
 });


### PR DESCRIPTION
[BACKLOG-6478] - Fixed template topics like:
 - Added new tag: code; to allow different case then example
 - Removed unneeded buttons for show/hide of Private, Inherited and Deprecated Class members
 - Fixed Method details template for Source Links
 - Removed duplicated code from member-details, using details (the correct one) instead
 - Updated method details for constructor, if that class is static and no constructor is needed
 - Updated Constructor location in the Class Page