### PR TITLE
[BACKLOG-6345] WD: add component: duplicate component name 'PostInitMarker' error appear in browser's console while reopening dashboard

### DIFF
--- a/core-js/src/main/javascript/cdf/dashboard/Dashboard.lifecycle.js
+++ b/core-js/src/main/javascript/cdf/dashboard/Dashboard.lifecycle.js
@@ -188,17 +188,19 @@ define([
       // Since we can get into racing conditions between last component's
       // preExecution and dashboard.postInit, we'll add a last component with very
       // low priority who's function is only to act as a marker.
-      var postInitComponent = new UnmanagedComponent({
-        name: "PostInitMarker",
-        type: "unmanaged",
-        lifecycle: {
-          silent: true
-        },
-        executeAtStart: true,
-        priority: 999999999
-      });
-      myself.addComponent(postInitComponent);  //TODO: check this!!!!
-      updating.push(postInitComponent);
+      if(!myself.getComponent("PostInitMarker")) {
+        var postInitComponent = new UnmanagedComponent({
+          name: "PostInitMarker",
+          type: "unmanaged",
+          lifecycle: {
+            silent: true
+          },
+          executeAtStart: true,
+          priority: 999999999
+        });
+        myself.addComponent(postInitComponent);  //TODO: check this!!!!
+        updating.push(postInitComponent);
+      }
 
       myself.waitingForInit = updating.slice();
 

--- a/core-js/src/test/javascript/cdf/dashboard/Dashboard.lifecycle-spec.js
+++ b/core-js/src/test/javascript/cdf/dashboard/Dashboard.lifecycle-spec.js
@@ -38,6 +38,7 @@ define([
     var shouldUpdate = new ManagedFreeformComponent({
       name: "shouldUpdate",
       type: "managedFreeform",
+      executeAtStart: true,
       preExecution: function() {},
       customfunction: function() {},
       postExecution: function() {}
@@ -503,6 +504,44 @@ define([
         // although comp3priority10 has been triggered for updating, it *should* be discarded from this execution cycle due to lower priority rate
         // (read: 1rst is comp2priority5, then is comp3priority10)
         expect(dashboard.othersAwaitExecution).toBeTruthy();
+      });
+    });
+
+    /**
+     * ## _initEngine function
+     */
+    describe("_initEngine function", function() {
+
+      it("doesn't add the PostInitMarker component if no components were added to the dashboard", function() {
+        spyOn(dashboard, "addComponent").and.callThrough();
+        expect(dashboard.getComponent("PostInitMarker")).toEqual(undefined);
+
+        dashboard._initEngine();
+
+        expect(dashboard.addComponent).not.toHaveBeenCalled();
+        expect(dashboard.getComponent("PostInitMarker")).toEqual(undefined);
+      });
+
+      it("doesn't add the PostInitMarker component if the components added to the dashboard don't have the executeAtStart flag set to true", function() {
+        spyOn(dashboard, "addComponent").and.callThrough();
+        expect(dashboard.getComponent("PostInitMarker")).toEqual(undefined);
+
+        dashboard.addComponent(shouldNotUpdate);
+        dashboard._initEngine();
+
+        expect(dashboard.addComponent).toHaveBeenCalled();
+        expect(dashboard.getComponent("PostInitMarker")).toEqual(undefined);
+      });
+
+      it("adds the PostInitMarker component if more components were added to the dashboard with the executeAtStart flag set to true", function() {
+        spyOn(dashboard, 'addComponent').and.callThrough();
+        expect(dashboard.getComponent("PostInitMarker")).toEqual(undefined);
+
+        dashboard.addComponent(shouldUpdate);
+        dashboard._initEngine();
+
+        expect(dashboard.addComponent).toHaveBeenCalled();
+        expect(dashboard.getComponent("PostInitMarker")).not.toEqual(undefined);
       });
     });
   });


### PR DESCRIPTION
     - avoid adding the "PostInitMarker" component more than once