### PR TITLE
[TEST] reviewed the usage of the optional "done" argument for async tests

### DIFF
--- a/core-js/src/test/javascript/cdf-legacy/components/input-spec-legacy.js
+++ b/core-js/src/test/javascript/cdf-legacy/components/input-spec-legacy.js
@@ -490,7 +490,7 @@ describe("The Multibutton Component #", function(){
       /**
        * ## The Multi Button Component # draw() function behaves correctly # with several elements in values array # with the current value does not equal to the first value
        */
-      describe("with the current value does not equal to the first value", function(done) {
+      describe("with the current value does not equal to the first value", function() {
         /**
          * ## The Multi Button Component # draw() function behaves correctly # with several elements in values array # with the current value does not equal to the first value # with the current value is present in values array
          */

--- a/core-js/src/test/javascript/cdf/components/CommentsComponent-spec.js
+++ b/core-js/src/test/javascript/cdf/components/CommentsComponent-spec.js
@@ -76,7 +76,7 @@ define([
       /**
        * ## The Comments Component # processOperation should list all comments
        */
-      it("should list all comments", function(done) {
+      it("should list all comments", function() {
         spyOn($, "ajax").and.callFake(function(params) {
           params.success({
             result: [],
@@ -116,7 +116,6 @@ define([
           collection,
           callback
         );
-        done();
       });
 
       /**
@@ -411,11 +410,11 @@ define([
     /**
      * ## The Comments Component # requestProcessing
      */
-    describe("requestProcessing", function(done) {
+    describe("requestProcessing", function() {
       /**
        * ## The Comments Component # requestProcessing should use cache-buster to avoid browser caching
        */
-      it("should use cache-buster to avoid browser caching", function(done) {
+      it("should use cache-buster to avoid browser caching", function() {
         spyOn($, "ajax").and.callFake(function(params) {
           params.success({
             result: [],
@@ -428,7 +427,6 @@ define([
           collection,
           callback);
         expect($.ajax.calls.mostRecent().args[0].url).toMatch(/comments\/list\?ts=[0-9]+/);
-        done();
       });
     });
   });

--- a/core-js/src/test/javascript/cdf/components/MultiButtonComponent-spec.js
+++ b/core-js/src/test/javascript/cdf/components/MultiButtonComponent-spec.js
@@ -211,7 +211,7 @@ define([
         /**
          * ## The Multi Button Component # draw() function behaves correctly # with several elements in values array # with the current value does not equal to the first value
          */
-        describe("with the current value does not equal to the first value", function(done) {
+        describe("with the current value does not equal to the first value", function() {
           /**
            * ## The Multi Button Component # draw() function behaves correctly # with several elements in values array # with the current value does not equal to the first value # with the current value is present in values array
            */


### PR DESCRIPTION
- `describe` blocks don't support the `done` parameter
- synchronous tests don't need the `done` parameter
