### PR TITLE
[SP-3201][CDF-949] CDF: Embeded Dashboards returns HTTP even when theconnection is done through SSL/TLS (https)

### DIFF
--- a/pentaho/src/main/java/org/pentaho/cdf/CdfApi.java
+++ b/pentaho/src/main/java/org/pentaho/cdf/CdfApi.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2015 Webdetails, a Pentaho company. All rights reserved.
+ * Copyright 2002 - 2017 Webdetails, a Pentaho company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -67,6 +67,8 @@ import pt.webdetails.cpf.utils.PluginIOUtils;
 public class CdfApi {
 
   private static final Log logger = LogFactory.getLog( CdfApi.class );
+  private static final String HTTP = "http";
+  private static final String HTTPS = "https";
 
   @GET
   @Path( "/ping" )
@@ -354,7 +356,7 @@ public class CdfApi {
     try {
       EmbeddedHeadersGenerator embeddedHeadersGenerator =
           new EmbeddedHeadersGenerator(
-            buildFullServerUrl( protocol, name, port ),
+            buildFullServerUrl( protocol, name, port, servletRequest.isSecure() ),
             getConfiguration( "",  Parameter.asHashMap( servletRequest ), inactiveInterval ) );
       if ( !StringUtils.isEmpty( locale ) ) {
         embeddedHeadersGenerator.setLocale( new Locale( locale ) );
@@ -372,10 +374,13 @@ public class CdfApi {
     return ContextEngine.getInstance().getConfig( path, parameterMap, inactiveInterval );
   }
 
-  protected String buildFullServerUrl( String protocol, String serverName, int serverPort  ) {
-    String p = "http";
+  protected String buildFullServerUrl( String protocol, String serverName, int serverPort, boolean secure ) {
+    String p = HTTP;
     if ( !StringUtils.isEmpty( protocol ) ) {
       p = protocol.split( "/" )[ 0 ].toLowerCase();
+    }
+    if ( HTTP.equalsIgnoreCase( p ) && secure ) {
+      p = HTTPS;
     }
     return p + "://" + serverName + ":" + serverPort + PentahoRequestContextHolder.getRequestContext().getContextPath();
   }

--- a/pentaho/src/test/java/org/pentaho/cdf/CdfApiTest.java
+++ b/pentaho/src/test/java/org/pentaho/cdf/CdfApiTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2015 Webdetails, a Pentaho company. All rights reserved.
+ * Copyright 2002 - 2017 Webdetails, a Pentaho company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -17,6 +17,9 @@ import junit.framework.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.pentaho.platform.api.engine.IPentahoRequestContext;
+import org.pentaho.platform.engine.core.system.PentahoRequestContextHolder;
 import pt.webdetails.cpf.messaging.MockHttpServletRequest;
 import pt.webdetails.cpf.messaging.MockHttpServletResponse;
 import pt.webdetails.cpf.utils.CharsetHelper;
@@ -67,5 +70,14 @@ public class CdfApiTest {
     Assert.assertTrue( servletResponse.getContentType().equals( APPLICATION_JSON ) );
     Assert.assertTrue( servletResponse.getCharacterEncoding().equals( CharsetHelper.getEncoding() ) );
     verify( cdfApi, times( 1 ) ).writeJSONSolution( PATH, DEPTH, SHOW_HIDDEN_FILES, MODE, servletResponse );
+  }
+  @Test
+  public void testBuildFullServerUrl() throws Exception {
+    CdfApi cdfApi = new CdfApi();
+    IPentahoRequestContext requestContext = Mockito.mock( IPentahoRequestContext.class );
+    Mockito.when( requestContext.getContextPath( ) ).thenReturn( "/rootContext" );
+    PentahoRequestContextHolder.setRequestContext( requestContext );
+    Assert.assertTrue( cdfApi.buildFullServerUrl( "HTTP/1.1", "localhost", 8080, true ).startsWith( "https://" ) );
+    Assert.assertTrue( cdfApi.buildFullServerUrl( "HTTP/1.1", "localhost", 8080, false ).startsWith( "http://" ) );
   }
 }


### PR DESCRIPTION
[SP-3201][CDF-949] CDF: Embeded Dashboards returns HTTP even when theconnection is done through SSL/TLS (https)

-added using scheme for HTTP protocol
-added tests