### PR TITLE
[BACKLOG-14077] 

### DIFF
--- a/core-js/src/main/javascript/cdf/components/ccc/BaseCccComponent.js
+++ b/core-js/src/main/javascript/cdf/components/ccc/BaseCccComponent.js
@@ -144,6 +144,11 @@ define([
       // Always clone the original chartDefinition.
       var cd = $.extend({}, this.chartDefinition);
 
+      // special case for this array which $.extend does not smash
+      if (cd.baseAxisLabelDesiredAngles && cd.baseAxisLabelDesiredAngles.length == 0) {
+        cd.baseAxisLabelDesiredAngles = undefined;
+      }
+
       if (externalChartDefinition) {
         cd = $.extend(externalChartDefinition, cd);
       }


### PR DESCRIPTION
 - Added special case for an array property, which should be smashed if the array is empty. This will be reviewed if we have more properties like this in the future

@pamval @dcleao @afrjorge please review