### PR TITLE
[ENGOPS-3041] ignoring the BaseCcc component from the generated doc.

### DIFF
--- a/core-js/src/main/javascript/cdf/components/ccc/BaseCccComponent.js
+++ b/core-js/src/main/javascript/cdf/components/ccc/BaseCccComponent.js
@@ -24,7 +24,12 @@ define([
 
   pvc.defaultCompatVersion(3);
 
-  return ChartComponent.extend({
+  /**
+   * @class cdf.components.ccc.BaseCccComponent
+   * @extends cdf.components.ChartComponent
+   * @ignore
+   */
+  return ChartComponent.extend(/** @lends cdf.components.ccc.BaseCccComponent# */{
 
     query: null,
     chart: null,


### PR DESCRIPTION
@afrjorge @lgrill-pentaho @hbfernandes pls review

this fixes the `mvn site` getting stuck