### PR TITLE
[PDB-1987] Check box filters with no default value set, display the first checkbox as selected

### DIFF
--- a/core-js/src/main/javascript/cdf-legacy/components/input.js
+++ b/core-js/src/main/javascript/cdf-legacy/components/input.js
@@ -70,7 +70,7 @@ var InputBaseComponent = UnmanagedComponent.extend({
 var SelectBaseComponent = InputBaseComponent.extend({
   visible: false,
 
-  //defaultIfEmpty: [false]
+  //useFirstValue:
   //isMultiple: [true]
   //size: when isMultiple==true, the default value is the number of possible values
   //externalPlugin:
@@ -161,12 +161,12 @@ var SelectBaseComponent = InputBaseComponent.extend({
 
     /* If the current value for the parameter is invalid or empty,
      * we need to pick a sensible default.
-     * If defaultIfEmpty is true, the first possible value is selected,
+     * If useFirstValue is `true`, the first possible value is selected,
      * otherwise, nothing is selected.
      */
     var isEmpty    = currentVals == null;
     var hasChanged = !currentIsValid;
-    if(isEmpty && this.defaultIfEmpty && firstVal != null) {
+    if(isEmpty && this.useFirstValue && firstVal != null) {
       // Won't remain empty
       currentVals = [firstVal];
       hasChanged = true;
@@ -420,7 +420,7 @@ var SelectBaseComponent = InputBaseComponent.extend({
 });
 
 var SelectComponent = SelectBaseComponent.extend({
-  defaultIfEmpty: true,
+  useFirstValue: true,
   getValue : function() {
     return this.placeholder("select").val();
   }
@@ -1064,15 +1064,14 @@ var ToggleButtonBaseComponent = InputBaseComponent.extend({
           }
         }
       }
-    // if there will be no selected value, but we're to default if empty, select the first
-    if(!hasCurrentVal && this.defaultIfEmpty){
+    // if empty and use first value, set the first value and update the parameter
+    if(!hasCurrentVal && this.useFirstValue){
       currentValArray = [myArray[0][vid]];
 
       this.currentVal = currentValArray;
       Dashboards.setParameter(this.parameter,currentValArray);
       Dashboards.processChange(this.name);
     }
-    // (currentValArray == null && this.defaultIfEmpty)? firstVal : null
 
 
     selectHTML += "<ul class='" + ((this.verticalOrientation)? "toggleGroup vertical":"toggleGroup horizontal") + "'>"
@@ -1096,7 +1095,7 @@ var ToggleButtonBaseComponent = InputBaseComponent.extend({
         }
         selectHTML += " type='radio'";
       }else{
-        if ((i == 0 && !hasCurrentVal && this.defaultIfEmpty) ||
+        if ((i == 0 && !hasCurrentVal && this.useFirstValue) ||
           (hasCurrentVal && isSelected)) {
           selectHTML += " CHECKED";
         }
@@ -1224,7 +1223,7 @@ var MultiButtonComponent = ToggleButtonBaseComponent.extend({
         }
       }
     }
-    if(((!foundDefault && !this.isMultiple) || (!foundDefault && this.isMultiple && this.defaultIfEmpty)) && myArray.length > 0){
+    if(((!foundDefault && !this.isMultiple) || (!foundDefault && this.isMultiple && this.useFirstValue)) && myArray.length > 0){
       //select first value
       if((currentVal == null || currentVal == "" || ((currentVal !== firstVal) && myArray.length == 1) ||
         (typeof(currentVal) == "object" && currentVal.length == 0)) && this.parameter){

--- a/core-js/src/main/javascript/cdf/components/MultiButtonComponent.js
+++ b/core-js/src/main/javascript/cdf/components/MultiButtonComponent.js
@@ -143,7 +143,7 @@ define([
           if(!myself.isMultiple) { break; }
         }
       }
-      if(((!foundDefault && !myself.isMultiple) || (!foundDefault && myself.isMultiple && myself.defaultIfEmpty))
+      if(((!foundDefault && !myself.isMultiple) || (!foundDefault && myself.isMultiple && myself.useFirstValue))
           && myArray.length > 0) {
 
         //select first value

--- a/core-js/src/main/javascript/cdf/components/SelectBaseComponent.js
+++ b/core-js/src/main/javascript/cdf/components/SelectBaseComponent.js
@@ -38,7 +38,7 @@ define([
      */
     visible: false,
 
-    //defaultIfEmpty: [false]
+    //useFirstValue:
     //isMultiple: [true]
     //size: when isMultiple==true, the default value is the number of possible values
     //externalPlugin:
@@ -131,12 +131,12 @@ define([
 
       /* If the current value for the parameter is invalid or empty,
        * we need to pick a sensible default.
-       * If defaultIfEmpty is true, the first possible value is selected,
+       * If useFirstValue is `true`, the first possible value is selected,
        * otherwise, nothing is selected.
        */
       var isEmpty = currentVals == null;
       var hasChanged = !currentIsValid;
-      if(isEmpty && this.defaultIfEmpty && firstVal != null) {
+      if(isEmpty && this.useFirstValue && firstVal != null) {
         // Won't remain empty
         currentVals = [firstVal];
         hasChanged = true;

--- a/core-js/src/main/javascript/cdf/components/SelectComponent.js
+++ b/core-js/src/main/javascript/cdf/components/SelectComponent.js
@@ -22,12 +22,12 @@ define(['./SelectBaseComponent'], function(SelectBaseComponent) {
    */
   return SelectBaseComponent.extend(/** @lends cdf.components.SelectComponent# */{
     /**
-     * Flag indicating if the default should show when the value is empty.
+     * Flag indicating if the first value available should be selected when the value is empty.
      *
      * @type {boolean}
      * @default
      */
-    defaultIfEmpty: true,
+    useFirstValue: true,
 
     /**
      * Gets the value of the `select` placeholder.

--- a/core-js/src/main/javascript/cdf/components/ToggleButtonBaseComponent.js
+++ b/core-js/src/main/javascript/cdf/components/ToggleButtonBaseComponent.js
@@ -43,15 +43,15 @@ define(['../lib/jquery', './InputBaseComponent'], function($, InputBaseComponent
           }
         }
       }
-      // if there will be no selected value, but we're to default if empty, select the first
-      if(!hasCurrentVal && myself.defaultIfEmpty) {
+      // if empty and use first value, set the first value and update the parameter
+      if(!hasCurrentVal && myself.useFirstValue) {
         currentValArray = [myArray[0][vid]];
 
         myself.currentVal = currentValArray;
         myself.dashboard.setParameter(myself.parameter, currentValArray);
         myself.dashboard.processChange(myself.name);
       }
-      // (currentValArray == null && myself.defaultIfEmpty)? firstVal : null
+      // (currentValArray == null && myself.useFirstValue)? firstVal : null
 
       var elClass = (myself.verticalOrientation) ? "toggleGroup vertical" : "toggleGroup horizontal";
       var selectHTML = $('<ul/>').attr({class: elClass});
@@ -76,7 +76,7 @@ define(['../lib/jquery', './InputBaseComponent'], function($, InputBaseComponent
           }
           input.attr({type: "radio"});
         } else {
-          if((i == 0 && !hasCurrentVal && myself.defaultIfEmpty) || (hasCurrentVal && isSelected)) {
+          if((i == 0 && !hasCurrentVal && myself.useFirstValue) || (hasCurrentVal && isSelected)) {
             input.prop('checked', true);
           }
           input.attr({type: "checkbox"});

--- a/core-js/src/test/javascript/cdf/components/ToggleButtonBaseComponent-spec.js
+++ b/core-js/src/test/javascript/cdf/components/ToggleButtonBaseComponent-spec.js
@@ -37,7 +37,7 @@ define([
           separator: ",&nbsp;",
           valueAsId: true,
           htmlObject: "sampleObject",
-          defaultIfEmpty: true
+          useFirstValue: true
         });
         dashboard.addComponent(comp);
 
@@ -81,7 +81,7 @@ define([
           valueAsId: false,
           htmlObject: "sampleObject",
           verticalOrientation: true,
-          defaultIfEmpty: true
+          useFirstValue: true
         });
         dashboard.addComponent(comp);
 
@@ -127,7 +127,7 @@ define([
           htmlObject: "sampleObject",
           executeAtStart: true,
           verticalOrientation: true,
-          defaultIfEmpty: true
+          useFirstValue: true
         });
         dashboard.addComponent(comp);
 


### PR DESCRIPTION
  - renamed the component property that controls first value selection, from `defaultIfEmpty` to `useFirstValue`, to be consistent with dashboards and common-ui plugins across the platform