### PR TITLE
[BACKLOG-22987] Fix typo in `enviroment` and not calling `toString`, …

### DIFF
--- a/pentaho-js/src/main/javascript/cdf/components/AnalyzerComponent.ext.js
+++ b/pentaho-js/src/main/javascript/cdf/components/AnalyzerComponent.ext.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2018 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use

--- a/pentaho-js/src/main/javascript/cdf/components/AnalyzerComponent.ext.js
+++ b/pentaho-js/src/main/javascript/cdf/components/AnalyzerComponent.ext.js
@@ -14,8 +14,8 @@
 define([
   '../dashboard/Dashboard.ext',
   'common-ui/util/URLEncoder',
-  'pentaho/enviroment'
-], function(DashboardExt, Encoder) {
+  'pentaho/environment'
+], function(DashboardExt, Encoder, environment) {
 
   return {
 

--- a/pentaho-js/src/main/javascript/cdf/components/ContentListComponent.js
+++ b/pentaho-js/src/main/javascript/cdf/components/ContentListComponent.js
@@ -105,7 +105,7 @@ define([
                 myself.draw($(this).attr("parentPath"));
               });
           } else {
-            var path = environment.server.root;
+            var path = environment.server.root.toString();
             if(this.url != undefined) {
               //cls = "folder";
               cls = "action greybox";

--- a/pentaho-js/src/test/javascript/cdf/mocks/pentaho/environment.js
+++ b/pentaho-js/src/test/javascript/cdf/mocks/pentaho/environment.js
@@ -12,12 +12,10 @@
  */
 
 define(function() {
-
   return {
     locale: "en-US",
     server: {
-      root: "/pentaho/"
+      root: {href: "/pentaho/", toString: function() { return this.href; }}
     }
   };
-
 });


### PR DESCRIPTION
…in another use of a URL object.

@webdetails/millenniumfalcon please review.