### PR TITLE
[CDF-1024] CPF InterPluginCall changed causing CDF autoIncludes to fail.

### DIFF
--- a/pentaho/src/main/java/org/pentaho/cdf/context/ContextEngine.java
+++ b/pentaho/src/main/java/org/pentaho/cdf/context/ContextEngine.java
@@ -417,7 +417,7 @@ public class ContextEngine {
   }
 
   protected boolean cdaExists() {
-    return ( new InterPluginCall( InterPluginCall.CDA, "" ) ).pluginExists();
+    return ( new InterPluginCall( InterPluginCall.CDA, "listQueries" ) ).pluginExists();
   }
 
   protected IUserContentAccess getUserContentAccess( String path ) {


### PR DESCRIPTION
The second parameter of an InterPluginCall expects a valid method that exists in the class.
Originally someone passed in "" or no method, this caused the method compare to fail and gave a false report that CDA was not installed.
listQueries is a valid method for CDA, and thus will have the check work and return true.

AutoInclude logic works and was unmodified.