### PR TITLE
[SP-4887] Backport of CDF-1024 - CPF InterPluginCall changed causing …

### DIFF
--- a/pentaho/src/main/java/org/pentaho/cdf/context/ContextEngine.java
+++ b/pentaho/src/main/java/org/pentaho/cdf/context/ContextEngine.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2019 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -417,7 +417,7 @@ public class ContextEngine {
   }
 
   protected boolean cdaExists() {
-    return ( new InterPluginCall( InterPluginCall.CDA, "" ) ).pluginExists();
+    return ( new InterPluginCall( InterPluginCall.CDA, "listQueries" ) ).pluginExists();
   }
 
   protected IUserContentAccess getUserContentAccess( String path ) {


### PR DESCRIPTION
…CDF autoIncludes to fail. (8.2 Suite)

The second parameter of an InterPluginCall expects a valid method that exists in the class.
Originally someone passed in "" or no method, this caused the method compare to fail and gave a false report that CDA was not installed.
listQueries is a valid method for CDA, and thus will have the check work and return true.

AutoInclude logic works and was unmodified.

Cherry-pick of: https://github.com/Webdetails/cdf/commit/ebca3c4f04c5f263f1c4e4eb0b2401bb7a7edddb

@LeonardoCoelho71950 @ssamora 