### PR TITLE
[BACKLOG-27092] - On IE11 and Edge the setTimeout requires to be boun…

### DIFF
--- a/core-js/src/main/javascript/cdf-core-lib-require-js-cfg.js
+++ b/core-js/src/main/javascript/cdf-core-lib-require-js-cfg.js
@@ -143,7 +143,8 @@
     deps: {
       "cdf/lib/jquery": "jQuery",
       "amd!cdf/lib/jquery.ui": ""
-    }
+    },
+    prescript: "var setTimeout = window.setTimeout.bind(window);\n" // Prevent setTimeout from throwing an 'Invalid calling object' exception on IE11 and Edge
   };
 
   //jquery-impromptu 5.2.4


### PR DESCRIPTION
…ded to window in the blockUi execution context to prevent "Invalid calling object" exception.