### PR TITLE
[CDF-1029] - 'Step by step tutorials' sample has a broken link to buy…

### DIFF
--- a/assemblies/cdf-samples/src/main/resources/plugin-samples/pentaho-cdf/legacy/40-support/template.html
+++ b/assemblies/cdf-samples/src/main/resources/plugin-samples/pentaho-cdf/legacy/40-support/template.html
@@ -10,14 +10,14 @@
 
 		<p>
 
-		CDF is released under the <a href="http://www.gnu.org/licenses/lgpl.html">LGPL</a>.
+		CDF is released under the <a target="_blank" href="http://www.gnu.org/licenses/lgpl.html">LGPL</a>.
 
 		</p>
 
 		<h2>Support</h2>
 		<p>
 		
-		<b><a href="http://www.webdetails.pt">WebDetails</a></b> offers consulting services and support to companies that
+		<b><a target="_blank" href="https://www.hitachivantara.com">Hitachi Vantara</a></b> offers consulting services and support to companies that
 		require assistance in developing dashboards using the CDF, from email support to complete dashboard development.
 
 		</p>
@@ -192,7 +192,7 @@
 		</div>
 		
 		
-		<h3><a href="https://training.pentaho.com/product/cdf-tutorial">Click here to buy the CDF Tutorial</a></h3>
+		<h3><a target="_blank" href="https://community.hitachivantara.com/docs/DOC-1009883-cdf-tutorial">Click here to buy the CDF Tutorial</a></h3>
 		
 		<b>By doing so you will: </b>
 		<ul>


### PR DESCRIPTION
… the CDF Tutorials

I slightly changed the user interface experience when clicking on a hyperlink it will be open in a new tab (this behavior already exists in another sample - Public\plugin-samples\CDF\Documentation\format ) .

This change was because when trying to load the URL in the current iframe the error "Refused to display 'https://www.hitachivantara.com' in a frame because it set 'X-Frame-Options' to 'sameorigin'" was raised. That error is regarding the response from server side namely on the meta tag X-Frame-Options: sameorigin.

@pentaho-lmartins @ppatricio @smmribeiro 