### PR TITLE
[BACKLOG-30893] Centralize commons-logging in parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
   <properties>
     <commons-io.version>1.3</commons-io.version>
     <commons-lang.version>2.2</commons-lang.version>
-    <commons-logging.version>1.1</commons-logging.version>
     <hibernate.version>3.2.6.ga</hibernate.version>
     <jxl.version>2.6.12</jxl.version>
     <pentaho-ccc-plugin.version>9.0.0.0-SNAPSHOT</pentaho-ccc-plugin.version>
@@ -75,17 +74,6 @@
         <artifactId>ccc</artifactId>
         <version>${pentaho-ccc-plugin.version}</version>
         <type>zip</type>
-      </dependency>
-      <dependency>
-        <groupId>commons-logging</groupId>
-        <artifactId>commons-logging</artifactId>
-        <version>${commons-logging.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>*</artifactId>
-            <groupId>*</groupId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>


### PR DESCRIPTION
Linked with this: pentaho/maven-parent-poms#163
