### PR TITLE
[BACKLOG-43874]-Fix JDK21 test pipeline(test1) build failures

### DIFF
--- a/assemblies/cdf/pom.xml
+++ b/assemblies/cdf/pom.xml
@@ -12,7 +12,6 @@
   <packaging>pom</packaging>
   <properties>
     <js.project.list>pentaho-cdf-js</js.project.list>
-    <maven-filtering.version>3.3.1</maven-filtering.version>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
[BACKLOG-43874]-Fix JDK21 test pipeline(test1) build failures

[BACKLOG-43874]: https://hv-eng.atlassian.net/browse/BACKLOG-43874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ