### PR TITLE
[BACKLOG-46173]-Fixing cdf master build failure

### DIFF
--- a/pentaho/src/test/java/org/pentaho/cdf/settings/SettingsApiTest.java
+++ b/pentaho/src/test/java/org/pentaho/cdf/settings/SettingsApiTest.java
@@ -16,7 +16,6 @@ package org.pentaho.cdf.settings;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;


### PR DESCRIPTION
[BACKLOG-46173]-Fixing cdf master build failure

[BACKLOG-46173]: https://hv-eng.atlassian.net/browse/BACKLOG-46173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ