### PR TITLE
[BACKLOG-43902]-Java 21 : compatibility check for Pentaho and fix Build and Run time issues while building / testing

### DIFF
--- a/assemblies/cdf/pom.xml
+++ b/assemblies/cdf/pom.xml
@@ -12,7 +12,6 @@
   <packaging>pom</packaging>
   <properties>
     <js.project.list>pentaho-cdf-js</js.project.list>
-    <maven-filtering.version>3.3.1</maven-filtering.version>
   </properties>
   <dependencies>
     <dependency>

--- a/assemblies/cdf/pom.xml
+++ b/assemblies/cdf/pom.xml
@@ -12,6 +12,7 @@
   <packaging>pom</packaging>
   <properties>
     <js.project.list>pentaho-cdf-js</js.project.list>
+    <maven-filtering.version>3.3.1</maven-filtering.version>
   </properties>
   <dependencies>
     <dependency>

--- a/assemblies/cdf/pom.xml
+++ b/assemblies/cdf/pom.xml
@@ -12,7 +12,7 @@
   <packaging>pom</packaging>
   <properties>
     <js.project.list>pentaho-cdf-js</js.project.list>
-    <maven-filtering.version>3.1.1</maven-filtering.version>
+    <maven-filtering.version>3.3.1</maven-filtering.version>
   </properties>
   <dependencies>
     <dependency>
@@ -78,6 +78,12 @@
       <resource>
         <filtering>true</filtering>
         <directory>${basedir}/src/main/resources</directory>
+        <excludes>
+          <exclude>**/*.icns</exclude>
+          <exclude>**/*.png</exclude>
+          <exclude>**/*.jpg</exclude>
+          <exclude>**/*.gif</exclude>
+        </excludes>
       </resource>
     </resources>
     <filters>


### PR DESCRIPTION
**Update Resource Filtering in Maven Build**
Modified the resource section to exclude image file types (*.icns, *.png, *.jpg, *.gif) from being included in resource processing.
This prevents unnecessary binary/image files from being processed or packaged unintentionally, improving build efficiency and artifact cleanliness.
With JDK 21, Maven and its plugins enforce stricter resource processing rules and improved validation during the build lifecycle. This can cause previously ignored or loosely handled files—such as images (*.png, *.jpg, etc.)—to:
Be unexpectedly processed or filtered, potentially causing build warnings or errors if binary files are filtered as text.
Trigger encoding or filtering issues, especially when filtering is enabled globally but not all resources are compatible (e.g., binary files).
By explicitly excluding these image files from resource filtering:
We ensure only relevant files are filtered, avoiding malformed output or plugin errors.