### PR TITLE
ci: fix parallel build (-T) failure in pentaho-cdf-rca [DEVO-14414]

### DIFF
--- a/assemblies/cdf-rca/pom.xml
+++ b/assemblies/cdf-rca/pom.xml
@@ -32,6 +32,21 @@
               <artifactId>cdf-pentaho-rca</artifactId>
               <version>${project.version}</version>
           </dependency>
+          <!--
+          Not consumed on the classpath. Declared solely so that the reactor
+          creates a dependency edge on pentaho-cdf and orders it before this
+          module. The maven-dependency-plugin <artifactItems> below are resolved
+          straight from the repositories at execution time and are invisible to
+          the reactor, which makes parallel builds (-T) race against the
+          pentaho-cdf assembly. See the unpack-plugins execution.
+          -->
+          <dependency>
+              <groupId>pentaho</groupId>
+              <artifactId>pentaho-cdf</artifactId>
+              <version>${project.version}</version>
+              <type>zip</type>
+              <scope>provided</scope>
+          </dependency>
       </dependencies>
       <build>
         <plugins>
@@ -40,7 +55,7 @@
                 <executions>
                     <execution>
                         <id>unpack-plugins</id>
-                        <phase>process-sources</phase>
+                        <phase>generate-resources</phase>
                         <goals>
                             <goal>unpack</goal>
                         </goals>


### PR DESCRIPTION
The unpack-plugins execution resolves pentaho:pentaho-cdf:zip via maven-dependency-plugin <artifactItems>, which are resolved directly from the repositories at execution time and do not participate in the reactor dependency graph. Serial builds only worked by accident of the <modules> declaration order; under -T the two modules are considered independent and run concurrently, so pentaho-cdf's zip is not yet attached when cdf-rca reaches process-sources.

- Declare pentaho-cdf explicitly (provided/zip) so the reactor orders it before this module.
- Move the unpack from process-sources to generate-resources, matching the pattern used by cdf-js and cdf-webpackage.